### PR TITLE
혼자 사용할 수 있도록 수정

### DIFF
--- a/Doolda/Doolda/Data/Repositories/UserRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/UserRepository.swift
@@ -49,7 +49,8 @@ class UserRepository: UserRepositoryProtocol {
     
     func setUser(_ user: User) -> AnyPublisher<User, Error> {
         guard let pairId = user.pairId else {
-            let publisher: AnyPublisher<UserDocument, Error> = self.urlSessionNetworkService.request(FirebaseAPIs.createUserDocument(user.id.ddidString))
+            let publisher: AnyPublisher<UserDocument, Error> =
+            self.urlSessionNetworkService.request(FirebaseAPIs.createUserDocument(user.id.ddidString))
             return publisher.tryMap { userDocument in
                 guard let newUser = userDocument.toUser() else {
                     throw UserRepositoryError.nilUserId
@@ -59,7 +60,8 @@ class UserRepository: UserRepositoryProtocol {
             .eraseToAnyPublisher()
         }
         
-        let publisher: AnyPublisher<UserDocument, Error> = self.urlSessionNetworkService.request(FirebaseAPIs.patchUserDocuement(user.id.ddidString, pairId.ddidString))
+        let publisher: AnyPublisher<UserDocument, Error> =
+        self.urlSessionNetworkService.request(FirebaseAPIs.patchUserDocuement(user.id.ddidString, pairId.ddidString))
         return publisher.tryMap { userDocument in
             guard let newUser = userDocument.toUser() else {
                 throw UserRepositoryError.nilUserId

--- a/Doolda/Doolda/Presentation/ViewModels/PairingViewModel.swift
+++ b/Doolda/Doolda/Presentation/ViewModels/PairingViewModel.swift
@@ -95,7 +95,7 @@ final class PairingViewModel: PairingViewModelProtocol {
     }
 
     func pairSkipButtonDidTap() {
-        
+        self.pairUserUseCase.pair(user: self.user)
     }
     
     func refreshButtonDidTap() {

--- a/Doolda/Doolda/Presentation/ViewModels/PairingViewModel.swift
+++ b/Doolda/Doolda/Presentation/ViewModels/PairingViewModel.swift
@@ -11,6 +11,7 @@ import Foundation
 protocol PairingViewModelInput {
     var friendIdInput: String { get set }
     func pairButtonDidTap()
+    func pairSkipButtonDidTap()
     func refreshButtonDidTap()
 }
 
@@ -91,6 +92,10 @@ final class PairingViewModel: PairingViewModelProtocol {
     func pairButtonDidTap() {
         guard let friendId = DDID(from: self.friendIdInput) else { return }
         self.pairUserUseCase.pair(user: self.user, friendId: friendId)
+    }
+
+    func pairSkipButtonDidTap() {
+        
     }
     
     func refreshButtonDidTap() {

--- a/Doolda/Doolda/UI/ViewControllers/PairingViewController.swift
+++ b/Doolda/Doolda/UI/ViewControllers/PairingViewController.swift
@@ -213,7 +213,7 @@ class PairingViewController: UIViewController {
             make.height.equalTo(44)
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)
-            //make.bottom.equalToSuperview()
+
         }
 
         self.contentView.addSubview(self.pairSkipButton)

--- a/Doolda/Doolda/UI/ViewControllers/PairingViewController.swift
+++ b/Doolda/Doolda/UI/ViewControllers/PairingViewController.swift
@@ -95,6 +95,20 @@ class PairingViewController: UIViewController {
         button.isEnabled = false
         return button
     }()
+
+    private lazy var pairSkipButton: UIButton = {
+        var configuration = UIButton.Configuration.filled()
+        configuration.cornerStyle = .capsule
+        var container = AttributeContainer()
+        // FIXME : change font to global font
+        container.font = UIFont(name: "Dovemayo", size: 16)
+        configuration.attributedTitle = AttributedString("혼자 쓰러가기", attributes: container)
+        configuration.baseBackgroundColor = .dooldaHighlighted
+        configuration.baseForegroundColor = .dooldaLabel
+        let button = UIButton(configuration: configuration)
+        button.isEnabled = true
+        return button
+    }()
     
     private lazy var divider: UIView = {
         let view = UIView()
@@ -199,6 +213,15 @@ class PairingViewController: UIViewController {
             make.height.equalTo(44)
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)
+            //make.bottom.equalToSuperview()
+        }
+
+        self.contentView.addSubview(self.pairSkipButton)
+        self.pairSkipButton.snp.makeConstraints { make in
+            make.top.equalTo(self.pairButton.snp.bottom).offset(20)
+            make.height.equalTo(self.pairButton)
+            make.leading.equalTo(self.pairButton)
+            make.trailing.equalTo(self.pairButton)
             make.bottom.equalToSuperview()
         }
     }
@@ -225,6 +248,13 @@ class PairingViewController: UIViewController {
             .sink { _ in
                 print("pair button did tap")
                 viewModel.pairButtonDidTap()
+            }
+            .store(in: &cancellables)
+
+        self.pairSkipButton.publisher(for: .touchUpInside)
+            .receive(on: DispatchQueue.main)
+            .sink { _ in
+                print("pair Skip button did tap")
             }
             .store(in: &cancellables)
 

--- a/Doolda/Doolda/UI/ViewControllers/PairingViewController.swift
+++ b/Doolda/Doolda/UI/ViewControllers/PairingViewController.swift
@@ -235,27 +235,27 @@ class PairingViewController: UIViewController {
             .sink { _ in
                 viewModel.refreshButtonDidTap()
             }
-            .store(in: &cancellables)
+            .store(in: &self.cancellables)
         
         self.friendIdTextField.publisher(for: .editingChanged)
             .receive(on: DispatchQueue.main)
             .compactMap { ($0 as? UITextField)?.text }
             .assign(to: \.friendIdInput, on: viewModel)
-            .store(in: &cancellables)
+            .store(in: &self.cancellables)
         
         self.pairButton.publisher(for: .touchUpInside)
             .receive(on: DispatchQueue.main)
             .sink { _ in
                 viewModel.pairButtonDidTap()
             }
-            .store(in: &cancellables)
+            .store(in: &self.cancellables)
 
         self.pairSkipButton.publisher(for: .touchUpInside)
             .receive(on: DispatchQueue.main)
             .sink { _ in
                 self.viewModel?.pairSkipButtonDidTap()
             }
-            .store(in: &cancellables)
+            .store(in: &self.cancellables)
 
         self.viewModel?.myId
             .receive(on: DispatchQueue.main)
@@ -269,7 +269,7 @@ class PairingViewController: UIViewController {
             .sink { [weak self] isValid in
                 self?.pairButton.isEnabled = isValid
             }
-            .store(in: &cancellables)
+            .store(in: &self.cancellables)
 
         self.viewModel?.errorPublisher
             .receive(on: DispatchQueue.main)
@@ -278,21 +278,21 @@ class PairingViewController: UIViewController {
                 guard let error = error as? LocalizedError else { return }
                 self?.presentAlert(message: error.localizedDescription)
             }
-            .store(in: &cancellables)
+            .store(in: &self.cancellables)
 
         self.view.publisher(for: UITapGestureRecognizer())
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.friendIdTextField.resignFirstResponder()
             }
-            .store(in: &cancellables)
+            .store(in: &self.cancellables)
         
         UIResponder.keyboardHeightPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] keyboardHeight in
                 self?.updateScrollView(with: keyboardHeight)
             }
-            .store(in: &cancellables)
+            .store(in: &self.cancellables)
     }
     
     // MARK: - Private Methods

--- a/Doolda/Doolda/UI/ViewControllers/PairingViewController.swift
+++ b/Doolda/Doolda/UI/ViewControllers/PairingViewController.swift
@@ -255,6 +255,7 @@ class PairingViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { _ in
                 print("pair Skip button did tap")
+                self.viewModel?.pairSkipButtonDidTap()
             }
             .store(in: &cancellables)
 

--- a/Doolda/Doolda/UI/ViewControllers/PairingViewController.swift
+++ b/Doolda/Doolda/UI/ViewControllers/PairingViewController.swift
@@ -246,7 +246,6 @@ class PairingViewController: UIViewController {
         self.pairButton.publisher(for: .touchUpInside)
             .receive(on: DispatchQueue.main)
             .sink { _ in
-                print("pair button did tap")
                 viewModel.pairButtonDidTap()
             }
             .store(in: &cancellables)
@@ -254,7 +253,6 @@ class PairingViewController: UIViewController {
         self.pairSkipButton.publisher(for: .touchUpInside)
             .receive(on: DispatchQueue.main)
             .sink { _ in
-                print("pair Skip button did tap")
                 self.viewModel?.pairSkipButtonDidTap()
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## 이슈 목록
- [x] #211

## 특이사항
* 연결하기 버튼 하단에 혼자 쓰러가기 버튼을 추가했습니다
* 혼자 사용하는 유저는 pairId를 자신의 id로 갖게 됩니다. 추후에 다이어리 페이지 작성하기 버튼을 만들때, pairId와 자신의 id가 같은지의 여부로 이 유저가 혼자 사용자는 유저인지, 다른 유저와 함께 사용하는지를 판별할 수 있습니다.
* 기존 pairingViewController에 코딩 컨벤션과 맞지 않은 부분이 있어, 리팩토링까지 진행했습니다.

## 실행 결과
| 라이트 모드 | 다크 모드 |
| ---- | ---- |
| <img width="307" alt="스크린샷 2021-11-14 오후 4 21 57" src="https://user-images.githubusercontent.com/61934702/141671499-cc994ba6-e052-4a2a-9919-030d21204c16.png"> | <img width="307" alt="스크린샷 2021-11-14 오후 4 22 19" src="https://user-images.githubusercontent.com/61934702/141671524-1a1c4632-2e84-43af-b47a-ac1fc1a3d565.png"> |

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

