### PR TITLE
PageRepository 기능 구현, PageDocument 정의, 추가적으로 필요한 Firestore API 구현

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		1D6232F527313D8E00A9AD6B /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F427313D8E00A9AD6B /* UIView+Extensions.swift */; };
 		1D6232F7273140CF00A9AD6B /* CopyableLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F6273140CF00A9AD6B /* CopyableLabel.swift */; };
 		1D6232F9273173E300A9AD6B /* UIResponder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F8273173E300A9AD6B /* UIResponder+Extensions.swift */; };
+		1D8BE0792740FE5E00201E3E /* PageDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BE0782740FE5E00201E3E /* PageDocument.swift */; };
 		1D992B42273D0EAB00B63954 /* PageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D992B41273D0EAB00B63954 /* PageRepository.swift */; };
 		1DBF5715273A2C5100D28F5E /* FontColorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBF5714273A2C5100D28F5E /* FontColorType.swift */; };
 		1DBF5717273A328D00D28F5E /* PhotoFrameType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBF5716273A328D00D28F5E /* PhotoFrameType.swift */; };
@@ -231,6 +232,7 @@
 		1D6232F427313D8E00A9AD6B /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		1D6232F6273140CF00A9AD6B /* CopyableLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyableLabel.swift; sourceTree = "<group>"; };
 		1D6232F8273173E300A9AD6B /* UIResponder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extensions.swift"; sourceTree = "<group>"; };
+		1D8BE0782740FE5E00201E3E /* PageDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDocument.swift; sourceTree = "<group>"; };
 		1D992B41273D0EAB00B63954 /* PageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageRepository.swift; sourceTree = "<group>"; };
 		1DBF5714273A2C5100D28F5E /* FontColorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontColorType.swift; sourceTree = "<group>"; };
 		1DBF5716273A328D00D28F5E /* PhotoFrameType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoFrameType.swift; sourceTree = "<group>"; };
@@ -656,6 +658,7 @@
 				FC5FB78F27325C4D008AC3D2 /* UserDocument.swift */,
 				FC5FB7942732627C008AC3D2 /* PairDocument.swift */,
 				66FE936C2735655C0036CED2 /* DDIDDataTransferObject.swift */,
+				1D8BE0782740FE5E00201E3E /* PageDocument.swift */,
 			);
 			path = DataTransferObjects;
 			sourceTree = "<group>";
@@ -1346,6 +1349,7 @@
 				319C21D0273BA7D4009CE65C /* ImageRepository.swift in Sources */,
 				310125D8273A6F6B00E43160 /* FileManagerPersistenceServiceProtocol.swift in Sources */,
 				66F5D47A2733E88F000FB471 /* PageEntity.swift in Sources */,
+				1D8BE0792740FE5E00201E3E /* PageDocument.swift in Sources */,
 				66FE9371273671910036CED2 /* PairUserUseCase.swift in Sources */,
 				1DE5E5362738BBAA004F794F /* CoordinatorProtocol.swift in Sources */,
 				66CD645A273BE5A000E55C03 /* PhotoPickerCollectionViewCell.swift in Sources */,

--- a/Doolda/Doolda/Data/DataTransferObjects/PageDocument.swift
+++ b/Doolda/Doolda/Data/DataTransferObjects/PageDocument.swift
@@ -10,17 +10,18 @@ import Foundation
 struct PageDocument: Codable {
     var authorId: String? { return self.fields["author"]?["stringValue"] }
     var pairId: String? { return self.fields["pairId"]?["stringValue"] }
-    var timestamp: String? { return self.fields["createdTime"]?["timestampValue"] }
+    var timeStamp: String? { return self.fields["createdTime"]?["timestampValue"] }
     var jsonPath: String? { return self.fields["jsonPath"]?["stringValue"] }
     let fields: [String: [String: String]]
     
     init(author: String, createdTime: Date, jsonPath: String, pairId: String) {
+        let formattedString = DateFormatter.firestoreFormatter.string(from: createdTime)
         self.fields = [
             "author": [
                 "stringValue": author
             ],
             "createdTime": [
-                "timestampValue": "2014-10-02T15:01:23Z"
+                "timestampValue": formattedString
             ],
             "jsonPath": [
                 "stringValue": jsonPath
@@ -57,9 +58,10 @@ struct PageDocument: Codable {
               let pairId = self.pairId,
               let authorDDID = DDID(from: authorId),
               let pairDDID = DDID(from: pairId),
-//              let date = Date(),
+              let timeStamp = self.timeStamp,
+              let formattedDate = DateFormatter.firestoreFormatter.date(from: timeStamp),
               let jsonPath = self.jsonPath else { return nil }
-        return PageEntity(author: User(id: authorDDID, pairId: pairDDID), timeStamp: Date(), jsonPath: jsonPath)
+        return PageEntity(author: User(id: authorDDID, pairId: pairDDID), timeStamp: formattedDate, jsonPath: jsonPath)
     }
 }
 

--- a/Doolda/Doolda/Data/DataTransferObjects/PageDocument.swift
+++ b/Doolda/Doolda/Data/DataTransferObjects/PageDocument.swift
@@ -64,7 +64,3 @@ struct PageDocument: Codable {
         return PageEntity(author: User(id: authorDDID, pairId: pairDDID), timeStamp: formattedDate, jsonPath: jsonPath)
     }
 }
-
-struct QueryDocument: Codable {
-    let document: [String: [String: [String: String]]]
-}

--- a/Doolda/Doolda/Data/DataTransferObjects/PageDocument.swift
+++ b/Doolda/Doolda/Data/DataTransferObjects/PageDocument.swift
@@ -1,0 +1,68 @@
+//
+//  PageDocument.swift
+//  Doolda
+//
+//  Created by Seunghun Yang on 2021/11/14.
+//
+
+import Foundation
+
+struct PageDocument: Codable {
+    var authorId: String? { return self.fields["author"]?["stringValue"] }
+    var pairId: String? { return self.fields["pairId"]?["stringValue"] }
+    var timestamp: String? { return self.fields["createdTime"]?["timestampValue"] }
+    var jsonPath: String? { return self.fields["jsonPath"]?["stringValue"] }
+    let fields: [String: [String: String]]
+    
+    init(author: String, createdTime: Date, jsonPath: String, pairId: String) {
+        self.fields = [
+            "author": [
+                "stringValue": author
+            ],
+            "createdTime": [
+                "timestampValue": "2014-10-02T15:01:23Z"
+            ],
+            "jsonPath": [
+                "stringValue": jsonPath
+            ],
+            "pairId": [
+                "stringValue": pairId
+            ]
+        ]
+    }
+    
+    init?(document: [String: [String: String]]) {
+        guard let author = document["author"]?["stringValue"],
+              let createdTime = document["createdTime"]?["timestampValue"],
+              let jsonPath = document["jsonPath"]?["stringValue"],
+              let pairId = document["pairId"]?["stringValue"] else { return nil }
+        self.fields = [
+            "author": [
+                "stringValue": author
+            ],
+            "createdTime": [
+                "timestampValue": createdTime
+            ],
+            "jsonPath": [
+                "stringValue": jsonPath
+            ],
+            "pairId": [
+                "stringValue": pairId
+            ]
+        ]
+    }
+    
+    func toPageEntity() -> PageEntity? {
+        guard let authorId = self.authorId,
+              let pairId = self.pairId,
+              let authorDDID = DDID(from: authorId),
+              let pairDDID = DDID(from: pairId),
+//              let date = Date(),
+              let jsonPath = self.jsonPath else { return nil }
+        return PageEntity(author: User(id: authorDDID, pairId: pairDDID), timeStamp: Date(), jsonPath: jsonPath)
+    }
+}
+
+struct QueryDocument: Codable {
+    let document: [String: [String: [String: String]]]
+}

--- a/Doolda/Doolda/Data/Interfaces/URLSessionNetworkServiceProtocol.swift
+++ b/Doolda/Doolda/Data/Interfaces/URLSessionNetworkServiceProtocol.swift
@@ -9,5 +9,7 @@ import Combine
 import Foundation
 
 protocol URLSessionNetworkServiceProtocol {
+    func request(_ urlRequest: URLRequestBuilder) -> AnyPublisher<Data, Error>
     func request<T: Decodable>(_ urlRequest: URLRequestBuilder) -> AnyPublisher<T, Error>
+    func request(_ urlRequest: URLRequestBuilder) -> AnyPublisher<[[String: Any]], Error>
 }

--- a/Doolda/Doolda/Data/Repositories/PageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PageRepository.swift
@@ -9,9 +9,19 @@ import Combine
 import Foundation
 
 class PageRepository: PageRepositoryProtocol {
-    // FIXME: not implemented
+    let urlSessionNetworkService: URLSessionNetworkServiceProtocol
+    
+    init(urlSessionNetworkService: URLSessionNetworkServiceProtocol) {
+        self.urlSessionNetworkService = urlSessionNetworkService
+    }
+    
     func savePage(_ page: PageEntity) -> AnyPublisher<PageEntity, Error> {
-        return Just(page).setFailureType(to: Error.self).eraseToAnyPublisher()
+        let request = FirebaseAPIs.createPageDocument(page.author.id.ddidString, page.timeStamp, page.jsonPath, page.author.pairId!.ddidString)
+        let publisher: AnyPublisher<[String: String], Error> = self.urlSessionNetworkService.request(request)
+        
+        return publisher
+            .map { _ in page }
+            .eraseToAnyPublisher()
     }
     
     // FIXME: not implemented

--- a/Doolda/Doolda/Data/Repositories/PageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PageRepository.swift
@@ -8,6 +8,16 @@
 import Combine
 import Foundation
 
+enum PageRepositoryError: LocalizedError {
+    case userNotPaired
+    
+    var errorDescription: String? {
+        switch self {
+        case .userNotPaired: return "페어링 된 유저가 없습니다."
+        }
+    }
+}
+
 class PageRepository: PageRepositoryProtocol {
     let urlSessionNetworkService: URLSessionNetworkServiceProtocol
     
@@ -16,7 +26,8 @@ class PageRepository: PageRepositoryProtocol {
     }
     
     func savePage(_ page: PageEntity) -> AnyPublisher<PageEntity, Error> {
-        let request = FirebaseAPIs.createPageDocument(page.author.id.ddidString, page.timeStamp, page.jsonPath, page.author.pairId!.ddidString)
+        guard let pairId = page.author.pairId?.ddidString else { return Fail(error: PageRepositoryError.userNotPaired).eraseToAnyPublisher() }
+        let request = FirebaseAPIs.createPageDocument(page.author.id.ddidString, page.timeStamp, page.jsonPath, pairId)
         let publisher: AnyPublisher<[String: String], Error> = self.urlSessionNetworkService.request(request)
         
         return publisher

--- a/Doolda/Doolda/Data/Repositories/PageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PageRepository.swift
@@ -42,11 +42,11 @@ class PageRepository: PageRepositoryProtocol {
             .map({ dictionaries in
                 var documents: [PageEntity] = []
                 dictionaries.forEach { dictionary in
-                    guard let something = dictionary["document"] as? [String: Any],
-                          let somethingElse = something["fields"] as? [String: [String: String]],
-                          let document = PageDocument(document: somethingElse),
-                          let entity = document.toPageEntity() else { return }
-                    documents.append(entity)
+                    guard let documentDictionary = dictionary["document"] as? [String: Any],
+                          let fieldsDictionary = documentDictionary["fields"] as? [String: [String: String]],
+                          let pageDocument = PageDocument(document: fieldsDictionary),
+                          let pageEntity = pageDocument.toPageEntity() else { return }
+                    documents.append(pageEntity)
                 }
                 return documents
             })

--- a/Doolda/Doolda/Support/Constants/API.swift
+++ b/Doolda/Doolda/Support/Constants/API.swift
@@ -17,6 +17,8 @@ enum FirebaseAPIs: URLRequestBuilder {
     case patchPairDocument(String, String)
     
     case createPageDocument(String, Date, String, String)
+    case getPageDocuments(String)
+
     case uploadDataFile(String, String, Data)
 }
 
@@ -42,6 +44,8 @@ extension FirebaseAPIs {
             return "documents/pair/\(pairId)"
         case .createPairDocument:
             return "documents/pair"
+        case .getPageDocuments:
+            return "documents:runQuery"
         case .createPageDocument:
             return "documents/page"
         default: return nil
@@ -71,7 +75,7 @@ extension FirebaseAPIs {
         switch self {
         case .getUserDocuement, .getPairDocument:
             return .get
-        case .createUserDocument, .createPairDocument, .uploadDataFile:
+        case .createUserDocument, .createPairDocument, .createPageDocument, .uploadDataFile, .getPageDocuments:
             return .post
         case .patchUserDocuement, .patchPairDocument:
             return .patch
@@ -95,6 +99,34 @@ extension FirebaseAPIs {
         switch self {
         case .getUserDocuement, .getPairDocument, .uploadDataFile:
             return nil
+        case .getPageDocuments(let pairId):
+            return [
+                "structuredQuery": [
+                    "from": [
+                        [
+                            "collectionId": "page",
+                            "allDescendants": true
+                        ]
+                    ],
+                    "where": [
+                        "fieldFilter": [
+                            "field": [
+                                "fieldPath": "pairId"
+                            ],
+                            "op": "EQUAL",
+                            "value": [
+                                "stringValue": pairId
+                            ]
+                        ]
+                    ],
+                    "orderBy": [
+                        "field": [
+                            "fieldPath": "createdTime"
+                        ],
+                        "direction": "DESCENDING"
+                    ]
+                ]
+            ]
         case .createUserDocument(let userId):
             let userDocument = UserDocument(userId: userId, pairId: "")
             return [

--- a/Doolda/Doolda/Support/Constants/API.swift
+++ b/Doolda/Doolda/Support/Constants/API.swift
@@ -15,7 +15,8 @@ enum FirebaseAPIs: URLRequestBuilder {
     case getPairDocument(String)
     case createPairDocument(String, String)
     case patchPairDocument(String, String)
-
+    
+    case createPageDocument(String, Date, String, String)
     case uploadDataFile(String, String, Data)
 }
 
@@ -41,6 +42,8 @@ extension FirebaseAPIs {
             return "documents/pair/\(pairId)"
         case .createPairDocument:
             return "documents/pair"
+        case .createPageDocument:
+            return "documents/page"
         default: return nil
         }
     }
@@ -49,10 +52,12 @@ extension FirebaseAPIs {
 extension FirebaseAPIs {
     var parameters: [String : String]? {
         switch self {
-        case .getUserDocuement, .getPairDocument:
+        case .getUserDocuement, .getPairDocument, .getPageDocuments:
             return nil
         case .createUserDocument(let id), .createPairDocument(let id, _):
             return ["documentId": id]
+        case .createPageDocument(_, _, let jsonPath, let pairId):
+            return ["documentId": pairId + jsonPath]
         case .patchUserDocuement, .patchPairDocument:
             return ["currentDocument.exists": "true"]
         case .uploadDataFile:
@@ -104,6 +109,11 @@ extension FirebaseAPIs {
             let pairDocument = PairDocument(pairId: pairId, recentlyEditedUser: recentlyEditedUser)
             return [
                 "fields": pairDocument.fields
+            ]
+        case .createPageDocument(let authorId, let createdTime, let jsonPath, let pairId):
+            let pageDocument = PageDocument(author: authorId, createdTime: createdTime, jsonPath: jsonPath, pairId: pairId)
+            return [
+                "fields": pageDocument.fields
             ]
         }
     }

--- a/Doolda/Doolda/Support/Extensions/DateFormatter+Extensions.swift
+++ b/Doolda/Doolda/Support/Extensions/DateFormatter+Extensions.swift
@@ -13,4 +13,10 @@ extension DateFormatter {
         formatter.dateFormat = "YYMMddHHmmss"
         return formatter
     }()
+    
+    static let firestoreFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        return formatter
+    }()
 }

--- a/Doolda/Doolda/UI/Coordinators/EditPageViewCoordinator.swift
+++ b/Doolda/Doolda/UI/Coordinators/EditPageViewCoordinator.swift
@@ -20,11 +20,13 @@ class EditPageViewCoordinator: EditPageViewCoordinatorProtocol {
     func start() {
         DispatchQueue.main.async {
             // FIXME : inject useCase and viewModel
+            let urlSessionNetworkService = URLSessionNetworkService()
+            
             let dummyImageUseCase = DummyImageUseCase()
-            let dummyPageRepository = DummyPageRepository(isSuccessMode: true)
+            let pageRepository = PageRepository(urlSessionNetworkService: urlSessionNetworkService)
             let dummyRawPageRepository = DummyRawPageRepository(isSuccessMode: true)
             
-            let editPageUseCase = EditPageUseCase(imageUseCase: dummyImageUseCase, pageRepository: dummyPageRepository, rawPageRepository: dummyRawPageRepository)
+            let editPageUseCase = EditPageUseCase(imageUseCase: dummyImageUseCase, pageRepository: pageRepository, rawPageRepository: dummyRawPageRepository)
             let editPageViewModel = EditPageViewModel(user: self.user, coordinator: self, editPageUseCase: editPageUseCase)
             let viewController = EditPageViewController(viewModel: editPageViewModel)
             self.presenter.setViewControllers([viewController], animated: false)


### PR DESCRIPTION
## 이슈 목록
- [x] #133 
- [x] #134 

## 특이사항
* 아.. 진짜 엔티티 + Firebase 최악이네요 ㅋㅋ
* Firestore 에서 데이터 query해오는거에서 엄청나게 삽질했습니다 (코딩도 못하고 계속 문서찾아보고 검색하고...)
* 결국에 해내긴했는데 코드가 지저분하고 맘에안드네요. No SQL은 여러모로 Swift Codable이랑 잘 안맞는다고 느껴져요. 괜히 구글이 SDK를 권장(?) 하는게 아닌듯..
* DB에 page 콜렉션에 `{pairId}+{jsonPath}` 라는 이름으로 `PageEntity`가 올라가게 구현했습니다.

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

