### PR TITLE
sticker관련 Presentation, Domain 단 구현

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		66FE9371273671910036CED2 /* PairUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FE9370273671910036CED2 /* PairUserUseCase.swift */; };
 		66FE9373273688E10036CED2 /* RefreshUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FE9372273688E10036CED2 /* RefreshUserUseCase.swift */; };
 		66FE93CC27396B960036CED2 /* PhotoPickerBottomSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FE93CB27396B950036CED2 /* PhotoPickerBottomSheetViewModel.swift */; };
+		FC19598A274284E200AB6059 /* StickerPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC195989274284E200AB6059 /* StickerPickerViewModel.swift */; };
 		FC5FB79027325C4D008AC3D2 /* UserDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB78F27325C4D008AC3D2 /* UserDocument.swift */; };
 		FC5FB79127325D2C008AC3D2 /* UserDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB78F27325C4D008AC3D2 /* UserDocument.swift */; };
 		FC5FB793273260C3008AC3D2 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB792273260C3008AC3D2 /* UserRepository.swift */; };
@@ -316,6 +317,7 @@
 		66FE9370273671910036CED2 /* PairUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairUserUseCase.swift; sourceTree = "<group>"; };
 		66FE9372273688E10036CED2 /* RefreshUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshUserUseCase.swift; sourceTree = "<group>"; };
 		66FE93CB27396B950036CED2 /* PhotoPickerBottomSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerBottomSheetViewModel.swift; sourceTree = "<group>"; };
+		FC195989274284E200AB6059 /* StickerPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerPickerViewModel.swift; sourceTree = "<group>"; };
 		FC5FB78F27325C4D008AC3D2 /* UserDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDocument.swift; sourceTree = "<group>"; };
 		FC5FB792273260C3008AC3D2 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 		FC5FB7942732627C008AC3D2 /* PairDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairDocument.swift; sourceTree = "<group>"; };
@@ -643,6 +645,7 @@
 				FCE9D3F327391F260001F155 /* EditPageViewModel.swift */,
 				66FE93CB27396B950036CED2 /* PhotoPickerBottomSheetViewModel.swift */,
 				1D8BE07C2743437600201E3E /* DiaryViewModel.swift */,
+				FC195989274284E200AB6059 /* StickerPickerViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1411,6 +1414,7 @@
 				1D6232EF2731117100A9AD6B /* UIControl+Extensions.swift in Sources */,
 				66FE9373273688E10036CED2 /* RefreshUserUseCase.swift in Sources */,
 				310D81482733F56700F15F4F /* DiaryViewController.swift in Sources */,
+				FC19598A274284E200AB6059 /* StickerPickerViewModel.swift in Sources */,
 				664893FA27302905009F03E2 /* SplashViewCoordinator.swift in Sources */,
 				FCE9D3DE2738CFB50001F155 /* PairRepository.swift in Sources */,
 				66FE93CC27396B960036CED2 /* PhotoPickerBottomSheetViewModel.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		FC5FB7E02733A6D5008AC3D2 /* FirebaseCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB7DF2733A6D5008AC3D2 /* FirebaseCollection.swift */; };
 		FC5FB7E12733A6D5008AC3D2 /* FirebaseCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB7DF2733A6D5008AC3D2 /* FirebaseCollection.swift */; };
 		FC5FB7E22733A6D5008AC3D2 /* FirebaseCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB7DF2733A6D5008AC3D2 /* FirebaseCollection.swift */; };
+		FC7AA339274345280059D0CD /* StickerUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7AA338274345280059D0CD /* StickerUseCase.swift */; };
 		FC822FAA2736088100C918A0 /* URLSessionNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC822FA92736088100C918A0 /* URLSessionNetworkService.swift */; };
 		FC822FAC27360F8600C918A0 /* URLRequsetBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC822FAB27360F8600C918A0 /* URLRequsetBuilder.swift */; };
 		FC822FB027367AFD00C918A0 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC822FAF27367AFD00C918A0 /* API.swift */; };
@@ -329,6 +330,7 @@
 		FC5FB7CB27339213008AC3D2 /* UserRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepositoryTests.swift; sourceTree = "<group>"; };
 		FC5FB7DB2733A4A9008AC3D2 /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
 		FC5FB7DF2733A6D5008AC3D2 /* FirebaseCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseCollection.swift; sourceTree = "<group>"; };
+		FC7AA338274345280059D0CD /* StickerUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerUseCase.swift; sourceTree = "<group>"; };
 		FC822FA92736088100C918A0 /* URLSessionNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionNetworkService.swift; sourceTree = "<group>"; };
 		FC822FAB27360F8600C918A0 /* URLRequsetBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequsetBuilder.swift; sourceTree = "<group>"; };
 		FC822FAF27367AFD00C918A0 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
@@ -725,6 +727,7 @@
 				310125C327398DF600E43160 /* ImageUseCase.swift */,
 				661A8405274351230077E0E3 /* CheckTurnUseCase.swift */,
 				661A840327434FE10077E0E3 /* GetPageUseCase.swift */,
+				FC7AA338274345280059D0CD /* StickerUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -1394,6 +1397,7 @@
 				FC822FAC27360F8600C918A0 /* URLRequsetBuilder.swift in Sources */,
 				310125922738325800E43160 /* UIAlertController+Extensions.swift in Sources */,
 				319C21CE273BA6D8009CE65C /* ImageRepositoryProtocol.swift in Sources */,
+				FC7AA339274345280059D0CD /* StickerUseCase.swift in Sources */,
 				661A840427434FE10077E0E3 /* GetPageUseCase.swift in Sources */,
 				1DE5E53E273929CE004F794F /* EditPageUseCase.swift in Sources */,
 				664893F4273023D3009F03E2 /* SplashViewController.swift in Sources */,

--- a/Doolda/Doolda/Domain/Entities/StickerComponentEntity.swift
+++ b/Doolda/Doolda/Domain/Entities/StickerComponentEntity.swift
@@ -9,27 +9,27 @@ import CoreGraphics
 import Foundation
 
 class StickerComponentEntity: ComponentEntity {
-    var name: String
+    var stickerUrl: URL
 
     private enum CodingKeys: String, CodingKey {
-        case name, type
+        case stickerUrl, type
     }
     
-    init(frame: CGRect, scale: CGFloat, angle: CGFloat, aspectRatio: CGFloat, name: String) {
-        self.name = name
+    init(frame: CGRect, scale: CGFloat, angle: CGFloat, aspectRatio: CGFloat, stickerUrl: URL) {
+        self.stickerUrl = stickerUrl
         super.init(frame: frame, scale: scale, angle: angle, aspectRatio: aspectRatio)
     }
     
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.name = try container.decode(String.self, forKey: .name)
+        self.stickerUrl = try container.decode(URL.self, forKey: .stickerUrl)
         try super.init(from: decoder)
     }
     
     override func encode(to encoder: Encoder) throws {
         try super.encode(to: encoder)
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(name, forKey: .name)
+        try container.encode(stickerUrl, forKey: .stickerUrl)
         try container.encode(ComponentType.sticker, forKey: .type)
     }
 }

--- a/Doolda/Doolda/Domain/Entities/StickerPackEntity.swift
+++ b/Doolda/Doolda/Domain/Entities/StickerPackEntity.swift
@@ -5,12 +5,23 @@
 //  Created by Dozzing on 2021/11/07.
 //
 
-import CoreGraphics
 import Foundation
 
 struct StickerPackEntity {
     let name: String
-    let packedImageName: String
-    let stickers: [String]
+    var stickersUrl: [URL]
     var isUnpacked: Bool = false
+    
+    init?(name: String) {
+        self.name = name
+        self.stickersUrl = []
+        for index in 0 ... 15 {
+            guard let stickerUrl = Bundle.main.url(forResource: name + "_\(index)", withExtension: "png") else { return nil }
+            self.stickersUrl.append(stickerUrl)
+        }
+    }
+    
+    static let colorStickerPack = StickerPackEntity(name: "colorSticker")
+    static let buddyStickerPack = StickerPackEntity(name: "buddySticker")
+    
 }

--- a/Doolda/Doolda/Domain/Entities/StickerPackEntity.swift
+++ b/Doolda/Doolda/Domain/Entities/StickerPackEntity.swift
@@ -7,6 +7,24 @@
 
 import Foundation
 
+enum StickerPackType: RawRepresentable, CaseIterable {
+    typealias RawValue = StickerPackEntity?
+
+    case color
+    case buddy
+    
+    init?(rawValue: RawValue) {
+        self = .color
+    }
+    
+    var rawValue: RawValue {
+        switch self {
+        case .color: return StickerPackEntity.colorStickerPack
+        case .buddy: return StickerPackEntity.buddyStickerPack
+        }
+    }
+}
+
 struct StickerPackEntity {
     let name: String
     var stickersUrl: [URL]

--- a/Doolda/Doolda/Domain/Entities/StickerPackEntity.swift
+++ b/Doolda/Doolda/Domain/Entities/StickerPackEntity.swift
@@ -41,5 +41,4 @@ struct StickerPackEntity {
     
     static let colorStickerPack = StickerPackEntity(name: "colorSticker")
     static let buddyStickerPack = StickerPackEntity(name: "buddySticker")
-    
 }

--- a/Doolda/Doolda/Domain/UseCases/StickerUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/StickerUseCase.swift
@@ -1,0 +1,35 @@
+//
+//  StickerUseCase.swift
+//  Doolda
+//
+//  Created by 김민주 on 2021/11/16.
+//
+
+import CoreGraphics
+import Foundation
+
+protocol StickerUseCaseProtocol {
+    var stickerPacks: [StickerPackType] { get }
+    func selectSticker(at indexPath: IndexPath) -> StickerComponentEntity?
+}
+
+class StickerUseCase: StickerUseCaseProtocol {
+    let stickerPacks: [StickerPackType]
+    
+    init() {
+        self.stickerPacks = StickerPackType.allCases
+    }
+    
+    func selectSticker(at indexPath: IndexPath) -> StickerComponentEntity? {
+        guard let selectedStickerPack = self.stickerPacks[indexPath.section].rawValue else { return nil }
+        
+        let stickerComponentEntity = StickerComponentEntity(
+            frame: CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 300, height: 300)),
+            scale: 1.0,
+            angle: 0,
+            aspectRatio: 1,
+            stickerUrl: selectedStickerPack.stickersUrl[indexPath.item]
+        )
+        return stickerComponentEntity
+    }
+}

--- a/Doolda/Doolda/Presentation/ViewModels/StickerPickerViewModel.swift
+++ b/Doolda/Doolda/Presentation/ViewModels/StickerPickerViewModel.swift
@@ -9,27 +9,22 @@ import CoreGraphics
 import Foundation
 
 protocol StickerPickerViewModelProtocol {
-    var stickerPack: [StickerPackType] { get }
+    func getStickerPacks() -> [StickerPackType]
     func stickerDidSelect(at indexPath: IndexPath) -> StickerComponentEntity?
 }
 
-
 class StickerPickerViewModel: StickerPickerViewModelProtocol {
-    let stickerPack: [StickerPackType]
+    private let stickerUseCase: StickerUseCase
     
-    init() {
-        self.stickerPack = StickerPackType.allCases
+    init(stickerUseCase: StickerUseCase) {
+        self.stickerUseCase = stickerUseCase
+    }
+    
+    func getStickerPacks() -> [StickerPackType] {
+        return stickerUseCase.stickerPacks
     }
     
     func stickerDidSelect(at indexPath: IndexPath) -> StickerComponentEntity? {
-        guard let selectedStickerPack = self.stickerPack[indexPath.section].rawValue else { return nil }
-        let stickerComponentEntity = StickerComponentEntity(
-            frame: CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 100, height: 100)),
-            scale: 1.0,
-            angle: 0,
-            aspectRatio: 1,
-            stickerUrl: selectedStickerPack.stickersUrl[indexPath.item]
-        )
-        return stickerComponentEntity
+        return self.stickerUseCase.selectSticker(at: indexPath)
     }
 }

--- a/Doolda/Doolda/Presentation/ViewModels/StickerPickerViewModel.swift
+++ b/Doolda/Doolda/Presentation/ViewModels/StickerPickerViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  StickerPickerViewModel.swift
+//  Doolda
+//
+//  Created by 김민주 on 2021/11/15.
+//
+
+import CoreGraphics
+import Foundation
+
+protocol StickerPickerViewModelProtocol {
+    var stickerPack: [StickerPackType] { get }
+    func stickerDidSelect(at indexPath: IndexPath) -> StickerComponentEntity?
+}
+
+
+class StickerPickerViewModel: StickerPickerViewModelProtocol {
+    let stickerPack: [StickerPackType]
+    
+    init() {
+        self.stickerPack = StickerPackType.allCases
+    }
+    
+    func stickerDidSelect(at indexPath: IndexPath) -> StickerComponentEntity? {
+        guard let selectedStickerPack = self.stickerPack[indexPath.section].rawValue else { return nil }
+        let stickerComponentEntity = StickerComponentEntity(
+            frame: CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 100, height: 100)),
+            scale: 1.0,
+            angle: 0,
+            aspectRatio: 1,
+            stickerUrl: selectedStickerPack.stickersUrl[indexPath.item]
+        )
+        return stickerComponentEntity
+    }
+}


### PR DESCRIPTION
## 이슈 목록
- [ ] #223 
- [ ] #224
- [ ] #227 
- [ ] #263 

## 특이사항
* 이부분 고민할 사항이 많은데 약간 가볍게 넘어간 것 같긴해요. 일단 제가 생긱하기로 가장 자연스러운 방법으로 코드를 짰는데 확인 한번만 부탁드립니다!
~~1. StickerPackEntity 안에 스티커를 불러올 수 있는 값
이부분에서 2가지 선택지가 있는데 stickerComponenetEntity의 배열을 통쨰로 가지게 하는 법과, 그걸 참조하는 url만 가지게 하는 방식이 있다고 생각했습니다. 첫번째는 개인적인 생각으로 entity한테 너무 많은 역할을 주는 것 같아서 (stickerComponenetEntity 정의하기 위해선 ㄴscale, frame 등을 알아야하기 때문에) 후자의 방향으로 갔습니다.
그래서 제가 생각한 방식은 이렇습니다
VC에서 탭으로 선택함 -> 그 선택한 indexPath로 VM의 배열에서 URL을 찾음 -> 그 URL을 찾아 componenetEntity를 생성하고 VC한테 다시 보냄 -> VC그걸 받아서 delegate로 전달~~


* UseCase에서 static엔티티를 가지고 있고 VC에서 선택한 indexpath에 따라 StickerComponentEntity를 넘겨주는 식으로 변경했습니다
혹시 제가 잘못 이해한 부분이 있다면 고쳐주시면 감사하겠습니다! 


## 셀프체크리스트
- [X] Merge 하는 브랜치가 올바른가?
- [X] 코딩컨벤션을 준수하는가?
- [X] PR과 관련없는 변경사항이 없는가?
- [X] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

