### PR TITLE
FirebaseCloudMessaging API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,4 +146,7 @@ GoogleService-Info.plist
 # SwiftPackageManager
 Package.resolved
 
+# Xcode Config
+*.xcconfig
+
 # End of https://www.toptal.com/developers/gitignore/api/swift,cocoapods,macos,xcode

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		1DD0F3572747ABFD00FC5E65 /* DDID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FE936A273564DB0036CED2 /* DDID.swift */; };
 		1DD0F3582747AC0300FC5E65 /* PageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F5D4792733E88F000FB471 /* PageEntity.swift */; };
 		1DD6AD4027321F7800592AC8 /* dovemayo.otf in Resources */ = {isa = PBXBuildFile; fileRef = 1DD6AD3F27321E5800592AC8 /* dovemayo.otf */; };
+		1DDADCB4274BCE63000330C9 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDADCB3274BCE63000330C9 /* Secrets.swift */; };
 		1DE5E5362738BBAA004F794F /* CoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE5E5352738BBAA004F794F /* CoordinatorProtocol.swift */; };
 		1DE5E5382738BCE0004F794F /* DiaryViewCoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE5E5372738BCE0004F794F /* DiaryViewCoordinatorProtocol.swift */; };
 		1DE5E53E273929CE004F794F /* EditPageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE5E53D273929CE004F794F /* EditPageUseCase.swift */; };
@@ -214,6 +215,8 @@
 		1DBF5714273A2C5100D28F5E /* FontColorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontColorType.swift; sourceTree = "<group>"; };
 		1DBF5716273A328D00D28F5E /* PhotoFrameType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoFrameType.swift; sourceTree = "<group>"; };
 		1DD6AD3F27321E5800592AC8 /* dovemayo.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = dovemayo.otf; sourceTree = "<group>"; };
+		1DDADCB2274BCB29000330C9 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		1DDADCB3274BCE63000330C9 /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		1DE5E5352738BBAA004F794F /* CoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorProtocol.swift; sourceTree = "<group>"; };
 		1DE5E5372738BCE0004F794F /* DiaryViewCoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryViewCoordinatorProtocol.swift; sourceTree = "<group>"; };
 		1DE5E53D273929CE004F794F /* EditPageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPageUseCase.swift; sourceTree = "<group>"; };
@@ -560,6 +563,7 @@
 				664893CB273007F1009F03E2 /* LaunchScreen.storyboard */,
 				664893CE273007F1009F03E2 /* Info.plist */,
 				665303992743B3FF00E3075C /* CoreDataModel.xcdatamodeld */,
+				1DDADCB2274BCB29000330C9 /* Config.xcconfig */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -741,6 +745,7 @@
 				FC5FB7DF2733A6D5008AC3D2 /* FirebaseCollection.swift */,
 				FC822FAF27367AFD00C918A0 /* API.swift */,
 				FCC803F52744C22F00FFE4DC /* DoolDaFont.swift */,
+				1DDADCB3274BCE63000330C9 /* Secrets.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -985,6 +990,7 @@
 				310125D6273A6F3400E43160 /* FileManagerPersistenceService.swift in Sources */,
 				FC5FB7E02733A6D5008AC3D2 /* FirebaseCollection.swift in Sources */,
 				1D9DC09D2749F2BE0060587B /* FilterOptionBottomSheetViewController.swift in Sources */,
+				1DDADCB4274BCE63000330C9 /* Secrets.swift in Sources */,
 				3161EE9827436EC600B922DD /* StickerPickerView.swift in Sources */,
 				1D6232F527313D8E00A9AD6B /* UIView+Extensions.swift in Sources */,
 				66CD6464273D125F00E55C03 /* CGImage+Extensions.swift in Sources */,
@@ -1332,6 +1338,7 @@
 		};
 		664893D2273007F1009F03E2 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DDADCB2274BCB29000330C9 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1359,6 +1366,7 @@
 		};
 		664893D3273007F1009F03E2 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DDADCB2274BCB29000330C9 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Doolda/Doolda/Resources/Info.plist
+++ b/Doolda/Doolda/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FCM_SERVER_KEY</key>
+	<string>$(FCM_SERVER_KEY)</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string></string>
 	<key>UIAppFonts</key>

--- a/Doolda/Doolda/Support/Constants/API.swift
+++ b/Doolda/Doolda/Support/Constants/API.swift
@@ -21,6 +21,8 @@ enum FirebaseAPIs: URLRequestBuilder {
 
     case uploadDataFile(String, String, Data)
     case downloadDataFile(String, String)
+    
+    case sendFirebaseMessage(String, String, String, [String: Any])
 }
 
 extension FirebaseAPIs {
@@ -57,7 +59,7 @@ extension FirebaseAPIs {
 extension FirebaseAPIs {
     var parameters: [String : String]? {
         switch self {
-        case .getUserDocuement, .getPairDocument, .getPageDocuments:
+        case .getUserDocuement, .getPairDocument, .getPageDocuments, .sendFirebaseMessage:
             return nil
         case .createUserDocument(let id), .createPairDocument(let id, _):
             return ["documentId": id]
@@ -76,7 +78,7 @@ extension FirebaseAPIs {
         switch self {
         case .getUserDocuement, .getPairDocument, .downloadDataFile:
             return .get
-        case .createUserDocument, .createPairDocument, .createPageDocument, .uploadDataFile, .getPageDocuments:
+        case .createUserDocument, .createPairDocument, .createPageDocument, .uploadDataFile, .getPageDocuments, .sendFirebaseMessage:
             return .post
         case .patchUserDocuement, .patchPairDocument:
             return .patch
@@ -89,6 +91,8 @@ extension FirebaseAPIs {
         switch self {
         case .uploadDataFile:
             return ["Content-Type": "application/octet-stream"]
+        case .sendFirebaseMessage:
+            return ["Content-Type": "application/json", "Authorization": "key=\(Secrets.fcmServerKey ?? "")"]
         default :
             return ["Content-Type": "application/json", "Accept": "application/json"]
         }
@@ -161,6 +165,17 @@ extension FirebaseAPIs {
             let pageDocument = PageDocument(author: authorId, createdTime: createdTime, jsonPath: jsonPath, pairId: pairId)
             return [
                 "fields": pageDocument.fields
+            ]
+        case .sendFirebaseMessage(let receiverToken, let title, let body, let data):
+            return [
+                "to": receiverToken,
+                "notification": [
+                    "title": title,
+                    "body": body,
+                    "mutable_content": true,
+                    "sound": "Tri-tone"
+                ],
+                "data": data
             ]
         }
     }

--- a/Doolda/Doolda/Support/Constants/API.swift
+++ b/Doolda/Doolda/Support/Constants/API.swift
@@ -30,6 +30,8 @@ extension FirebaseAPIs {
         switch self {
         case .uploadDataFile(let pairId, let fileName, _), .downloadDataFile(let pairId, let fileName):
             return URL(string: "https://firebasestorage.googleapis.com/v0/b/doolda.appspot.com/o/\(pairId)%2F\(fileName)")
+        case .sendFirebaseMessage:
+            return URL(string: "https://fcm.googleapis.com/fcm/send")
         default:
             return URL(string: "https://firestore.googleapis.com/v1/projects/doolda/databases/(default)/")
         }

--- a/Doolda/Doolda/Support/Constants/Secrets.swift
+++ b/Doolda/Doolda/Support/Constants/Secrets.swift
@@ -1,0 +1,12 @@
+//
+//  Secrets.swift
+//  Doolda
+//
+//  Created by Seunghun Yang on 2021/11/22.
+//
+
+import Foundation
+
+enum Secrets {
+    static let fcmServerKey = Bundle.main.infoDictionary?["FCM_SERVER_KEY"] as? String
+}


### PR DESCRIPTION
## 이슈 목록
- [x] #354 

## 특이사항
* 해봤는데 아주아주아주아주잘돼요. 이제 협의하고 사용하는쪽만 고려해주면 될 듯 합니다.
* API Key 관련해서는 `.xcconfig` 파일에 담아두고 `Secrets` 에 `static let` 으로 선언해두고 쓰는방식이 좋을 것 같아서 그렇게했는데 어떤지 알려주세요. 참고로 `.xcconfig` 는 `.gitignore` 에 추가했으니 slack을 통해서 공유할게요

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

