### PR TITLE
settings view 일부 구현

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		317FB611274A9175005DF3A3 /* SettingsViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */; };
 		317FB613274AA879005DF3A3 /* SettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */; };
 		317FB615274B9A92005DF3A3 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */; };
+		317FB617274BAAEC005DF3A3 /* DooldaInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB616274BAAEB005DF3A3 /* DooldaInfoType.swift */; };
 		319C21CE273BA6D8009CE65C /* ImageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */; };
 		319C21D0273BA7D4009CE65C /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CF273BA7D4009CE65C /* ImageRepository.swift */; };
 		319C21D8273BD764009CE65C /* URLSessionNetworkServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21D7273BD764009CE65C /* URLSessionNetworkServiceTest.swift */; };
@@ -260,6 +261,7 @@
 		317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewCoordinator.swift; sourceTree = "<group>"; };
 		317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewCell.swift; sourceTree = "<group>"; };
 		317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		317FB616274BAAEB005DF3A3 /* DooldaInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DooldaInfoType.swift; sourceTree = "<group>"; };
 		319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryProtocol.swift; sourceTree = "<group>"; };
 		319C21CF273BA7D4009CE65C /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		319C21D5273BD764009CE65C /* URLSessionNetworkServiceTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = URLSessionNetworkServiceTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -702,6 +704,7 @@
 				1DBF5714273A2C5100D28F5E /* FontColorType.swift */,
 				31012597273842DA00E43160 /* TextComponentEntity.swift */,
 				3101259B2738430200E43160 /* StickerPackEntity.swift */,
+				317FB616274BAAEB005DF3A3 /* DooldaInfoType.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -1019,6 +1022,7 @@
 				1D9DC09F274A0E290060587B /* FilterOptionBottomSheetViewModel.swift in Sources */,
 				319C222D273CEFBB009CE65C /* CIImage+Extension.swift in Sources */,
 				661A8406274351230077E0E3 /* CheckMyTurnUseCase.swift in Sources */,
+				317FB617274BAAEC005DF3A3 /* DooldaInfoType.swift in Sources */,
 				1D3629FE2733C79300CFC069 /* RegisterUserUseCase.swift in Sources */,
 				FCD24D7827439717000203F7 /* GlobalFontUseCase.swift in Sources */,
 				1D999464274CAAAC00C72273 /* FCMTokenRepositoryProtocol.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		317FB613274AA879005DF3A3 /* SettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */; };
 		317FB615274B9A92005DF3A3 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */; };
 		317FB617274BAAEC005DF3A3 /* DooldaInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB616274BAAEB005DF3A3 /* DooldaInfoType.swift */; };
+		317FB619274BBC9D005DF3A3 /* SettingsTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB618274BBC9D005DF3A3 /* SettingsTableViewHeader.swift */; };
 		319C21CE273BA6D8009CE65C /* ImageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */; };
 		319C21D0273BA7D4009CE65C /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CF273BA7D4009CE65C /* ImageRepository.swift */; };
 		319C21D8273BD764009CE65C /* URLSessionNetworkServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21D7273BD764009CE65C /* URLSessionNetworkServiceTest.swift */; };
@@ -262,6 +263,7 @@
 		317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewCell.swift; sourceTree = "<group>"; };
 		317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		317FB616274BAAEB005DF3A3 /* DooldaInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DooldaInfoType.swift; sourceTree = "<group>"; };
+		317FB618274BBC9D005DF3A3 /* SettingsTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewHeader.swift; sourceTree = "<group>"; };
 		319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryProtocol.swift; sourceTree = "<group>"; };
 		319C21CF273BA7D4009CE65C /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		319C21D5273BD764009CE65C /* URLSessionNetworkServiceTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = URLSessionNetworkServiceTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -402,6 +404,7 @@
 			children = (
 				317FB60C274A8F59005DF3A3 /* SettingsViewController.swift */,
 				317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */,
+				317FB618274BBC9D005DF3A3 /* SettingsTableViewHeader.swift */,
 				317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */,
 				317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */,
 				317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */,
@@ -1083,6 +1086,7 @@
 				1D9DC0A5274B8A890060587B /* Collection+Extensions.swift in Sources */,
 				664893FA27302905009F03E2 /* SplashViewCoordinator.swift in Sources */,
 				FCE9D3DE2738CFB50001F155 /* PairRepository.swift in Sources */,
+				317FB619274BBC9D005DF3A3 /* SettingsTableViewHeader.swift in Sources */,
 				317FB60B274A3851005DF3A3 /* StickerPickerCollectionViewFooter.swift in Sources */,
 				66FE93CC27396B960036CED2 /* PhotoPickerBottomSheetViewModel.swift in Sources */,
 				317FB60F274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		317FB60F274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */; };
 		317FB611274A9175005DF3A3 /* SettingsViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */; };
 		317FB613274AA879005DF3A3 /* SettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */; };
+		317FB615274B9A92005DF3A3 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */; };
 		319C21CE273BA6D8009CE65C /* ImageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */; };
 		319C21D0273BA7D4009CE65C /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CF273BA7D4009CE65C /* ImageRepository.swift */; };
 		319C21D8273BD764009CE65C /* URLSessionNetworkServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21D7273BD764009CE65C /* URLSessionNetworkServiceTest.swift */; };
@@ -164,7 +165,6 @@
 		FC9F10582730F0060060FEB7 /* GetMyIdUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9F10572730F0060060FEB7 /* GetMyIdUseCase.swift */; };
 		FC9F105B2730F1B20060FEB7 /* UserRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9F105A2730F1B20060FEB7 /* UserRepositoryProtocol.swift */; };
 		FCC803F62744C22F00FFE4DC /* DoolDaFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC803F52744C22F00FFE4DC /* DoolDaFont.swift */; };
-		FCC803F82744FEF800FFE4DC /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC803F72744FEF800FFE4DC /* SettingsViewModel.swift */; };
 		FCC803FA27451A8000FFE4DC /* TextEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC803F927451A8000FFE4DC /* TextEditViewController.swift */; };
 		FCC803FC27451C9600FFE4DC /* TextEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC803FB27451C9600FFE4DC /* TextEditViewModel.swift */; };
 		FCCF022F273A12B400EAB00B /* EditPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCF022E273A12B400EAB00B /* EditPageViewController.swift */; };
@@ -259,6 +259,7 @@
 		317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewCoordinatorProtocol.swift; sourceTree = "<group>"; };
 		317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewCoordinator.swift; sourceTree = "<group>"; };
 		317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewCell.swift; sourceTree = "<group>"; };
+		317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryProtocol.swift; sourceTree = "<group>"; };
 		319C21CF273BA7D4009CE65C /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		319C21D5273BD764009CE65C /* URLSessionNetworkServiceTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = URLSessionNetworkServiceTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -323,7 +324,6 @@
 		FC9F10572730F0060060FEB7 /* GetMyIdUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMyIdUseCase.swift; sourceTree = "<group>"; };
 		FC9F105A2730F1B20060FEB7 /* UserRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepositoryProtocol.swift; sourceTree = "<group>"; };
 		FCC803F52744C22F00FFE4DC /* DoolDaFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoolDaFont.swift; sourceTree = "<group>"; };
-		FCC803F72744FEF800FFE4DC /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		FCC803F927451A8000FFE4DC /* TextEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditViewController.swift; sourceTree = "<group>"; };
 		FCC803FB27451C9600FFE4DC /* TextEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditViewModel.swift; sourceTree = "<group>"; };
 		FCCF022E273A12B400EAB00B /* EditPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPageViewController.swift; sourceTree = "<group>"; };
@@ -400,7 +400,7 @@
 			children = (
 				317FB60C274A8F59005DF3A3 /* SettingsViewController.swift */,
 				317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */,
-				FCC803F72744FEF800FFE4DC /* SettingsViewModel.swift */,
+				317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */,
 				317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */,
 				317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */,
 			);
@@ -1086,7 +1086,6 @@
 				66CD6450273A5C4700E55C03 /* PhotoPickerBottomSheetViewController.swift in Sources */,
 				FCD24D7C2743AAE2000203F7 /* PushNotificationStateRepositoryProtocol.swift in Sources */,
 				FC9F10582730F0060060FEB7 /* GetMyIdUseCase.swift in Sources */,
-				FCC803F82744FEF800FFE4DC /* SettingsViewModel.swift in Sources */,
 				1DBF5717273A328D00D28F5E /* PhotoFrameType.swift in Sources */,
 				3161EE9A274377E300B922DD /* PackedStickerCollectionViewCell.swift in Sources */,
 				3161EE942742A44100B922DD /* StickerPickerBottomSheetViewController.swift in Sources */,
@@ -1132,6 +1131,7 @@
 				1D097E97273CFA5900A4810B /* RawPageRepository.swift in Sources */,
 				1D9DC0A1274A47D50060587B /* DooldaButton.swift in Sources */,
 				310125A027393D3B00E43160 /* ImageComposeUseCase.swift in Sources */,
+				317FB615274B9A92005DF3A3 /* SettingsViewModel.swift in Sources */,
 				310D80D52731405B00F15F4F /* DiaryViewCoordinator.swift in Sources */,
 				66ECCD3A273E5342003990EE /* CarouselView.swift in Sources */,
 				66CAFF242740F63A00A48DCF /* BackgroundTypePickerViewController.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		317FB615274B9A92005DF3A3 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */; };
 		317FB617274BAAEC005DF3A3 /* DooldaInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB616274BAAEB005DF3A3 /* DooldaInfoType.swift */; };
 		317FB619274BBC9D005DF3A3 /* SettingsTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB618274BBC9D005DF3A3 /* SettingsTableViewHeader.swift */; };
+		317FB61B274BCE68005DF3A3 /* SettingsOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB61A274BCE68005DF3A3 /* SettingsOptionViewController.swift */; };
 		319C21CE273BA6D8009CE65C /* ImageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */; };
 		319C21D0273BA7D4009CE65C /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CF273BA7D4009CE65C /* ImageRepository.swift */; };
 		319C21D8273BD764009CE65C /* URLSessionNetworkServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21D7273BD764009CE65C /* URLSessionNetworkServiceTest.swift */; };
@@ -264,6 +265,7 @@
 		317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		317FB616274BAAEB005DF3A3 /* DooldaInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DooldaInfoType.swift; sourceTree = "<group>"; };
 		317FB618274BBC9D005DF3A3 /* SettingsTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewHeader.swift; sourceTree = "<group>"; };
+		317FB61A274BCE68005DF3A3 /* SettingsOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsOptionViewController.swift; sourceTree = "<group>"; };
 		319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryProtocol.swift; sourceTree = "<group>"; };
 		319C21CF273BA7D4009CE65C /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		319C21D5273BD764009CE65C /* URLSessionNetworkServiceTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = URLSessionNetworkServiceTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -408,6 +410,7 @@
 				317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */,
 				317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */,
 				317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */,
+				317FB61A274BCE68005DF3A3 /* SettingsOptionViewController.swift */,
 			);
 			path = SettingsScene;
 			sourceTree = "<group>";
@@ -1117,6 +1120,7 @@
 				1D999468274CAC4700C72273 /* FCMTokenDocument.swift in Sources */,
 				1DE5E540273932B0004F794F /* PageRepositoryProtocol.swift in Sources */,
 				665303A62743E09A00E3075C /* CoreDataPersistenceServiceProtocol.swift in Sources */,
+				317FB61B274BCE68005DF3A3 /* SettingsOptionViewController.swift in Sources */,
 				1D992B42273D0EAB00B63954 /* PageRepository.swift in Sources */,
 				FC5FB79A273284E2008AC3D2 /* UserDefaultsPersistenceService.swift in Sources */,
 				664893FC27302947009F03E2 /* SplashViewModel.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -100,7 +100,7 @@
 		317FB615274B9A92005DF3A3 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */; };
 		317FB617274BAAEC005DF3A3 /* DooldaInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB616274BAAEB005DF3A3 /* DooldaInfoType.swift */; };
 		317FB619274BBC9D005DF3A3 /* SettingsTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB618274BBC9D005DF3A3 /* SettingsTableViewHeader.swift */; };
-		317FB61B274BCE68005DF3A3 /* SettingsOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB61A274BCE68005DF3A3 /* SettingsOptionViewController.swift */; };
+		317FB61B274BCE68005DF3A3 /* SettingsDetailedInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB61A274BCE68005DF3A3 /* SettingsDetailedInfoViewController.swift */; };
 		319C21CE273BA6D8009CE65C /* ImageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */; };
 		319C21D0273BA7D4009CE65C /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CF273BA7D4009CE65C /* ImageRepository.swift */; };
 		319C21D8273BD764009CE65C /* URLSessionNetworkServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21D7273BD764009CE65C /* URLSessionNetworkServiceTest.swift */; };
@@ -265,7 +265,7 @@
 		317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		317FB616274BAAEB005DF3A3 /* DooldaInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DooldaInfoType.swift; sourceTree = "<group>"; };
 		317FB618274BBC9D005DF3A3 /* SettingsTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewHeader.swift; sourceTree = "<group>"; };
-		317FB61A274BCE68005DF3A3 /* SettingsOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsOptionViewController.swift; sourceTree = "<group>"; };
+		317FB61A274BCE68005DF3A3 /* SettingsDetailedInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDetailedInfoViewController.swift; sourceTree = "<group>"; };
 		319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryProtocol.swift; sourceTree = "<group>"; };
 		319C21CF273BA7D4009CE65C /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		319C21D5273BD764009CE65C /* URLSessionNetworkServiceTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = URLSessionNetworkServiceTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -405,12 +405,12 @@
 			isa = PBXGroup;
 			children = (
 				317FB60C274A8F59005DF3A3 /* SettingsViewController.swift */,
+				317FB61A274BCE68005DF3A3 /* SettingsDetailedInfoViewController.swift */,
 				317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */,
 				317FB618274BBC9D005DF3A3 /* SettingsTableViewHeader.swift */,
 				317FB614274B9A92005DF3A3 /* SettingsViewModel.swift */,
 				317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */,
 				317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */,
-				317FB61A274BCE68005DF3A3 /* SettingsOptionViewController.swift */,
 			);
 			path = SettingsScene;
 			sourceTree = "<group>";
@@ -1120,7 +1120,7 @@
 				1D999468274CAC4700C72273 /* FCMTokenDocument.swift in Sources */,
 				1DE5E540273932B0004F794F /* PageRepositoryProtocol.swift in Sources */,
 				665303A62743E09A00E3075C /* CoreDataPersistenceServiceProtocol.swift in Sources */,
-				317FB61B274BCE68005DF3A3 /* SettingsOptionViewController.swift in Sources */,
+				317FB61B274BCE68005DF3A3 /* SettingsDetailedInfoViewController.swift in Sources */,
 				1D992B42273D0EAB00B63954 /* PageRepository.swift in Sources */,
 				FC5FB79A273284E2008AC3D2 /* UserDefaultsPersistenceService.swift in Sources */,
 				664893FC27302947009F03E2 /* SplashViewModel.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		317FB60D274A8F59005DF3A3 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB60C274A8F59005DF3A3 /* SettingsViewController.swift */; };
 		317FB60F274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */; };
 		317FB611274A9175005DF3A3 /* SettingsViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */; };
+		317FB613274AA879005DF3A3 /* SettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */; };
 		319C21CE273BA6D8009CE65C /* ImageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */; };
 		319C21D0273BA7D4009CE65C /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CF273BA7D4009CE65C /* ImageRepository.swift */; };
 		319C21D8273BD764009CE65C /* URLSessionNetworkServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21D7273BD764009CE65C /* URLSessionNetworkServiceTest.swift */; };
@@ -257,6 +258,7 @@
 		317FB60C274A8F59005DF3A3 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewCoordinatorProtocol.swift; sourceTree = "<group>"; };
 		317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewCoordinator.swift; sourceTree = "<group>"; };
+		317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewCell.swift; sourceTree = "<group>"; };
 		319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryProtocol.swift; sourceTree = "<group>"; };
 		319C21CF273BA7D4009CE65C /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		319C21D5273BD764009CE65C /* URLSessionNetworkServiceTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = URLSessionNetworkServiceTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -397,6 +399,7 @@
 			isa = PBXGroup;
 			children = (
 				317FB60C274A8F59005DF3A3 /* SettingsViewController.swift */,
+				317FB612274AA879005DF3A3 /* SettingsTableViewCell.swift */,
 				FCC803F72744FEF800FFE4DC /* SettingsViewModel.swift */,
 				317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */,
 				317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */,
@@ -1089,6 +1092,7 @@
 				3161EE942742A44100B922DD /* StickerPickerBottomSheetViewController.swift in Sources */,
 				FCC803F62744C22F00FFE4DC /* DoolDaFont.swift in Sources */,
 				FCE9D3DC2738C9A00001F155 /* PairRepositoryProtocol.swift in Sources */,
+				317FB613274AA879005DF3A3 /* SettingsTableViewCell.swift in Sources */,
 				317FB60D274A8F59005DF3A3 /* SettingsViewController.swift in Sources */,
 				FC822FB027367AFD00C918A0 /* API.swift in Sources */,
 				FCCF022F273A12B400EAB00B /* EditPageViewController.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -93,6 +93,9 @@
 		3161EE9A274377E300B922DD /* PackedStickerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3161EE99274377E300B922DD /* PackedStickerCollectionViewCell.swift */; };
 		3161EE9C274377F400B922DD /* UnpackedStickerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3161EE9B274377F400B922DD /* UnpackedStickerCollectionViewCell.swift */; };
 		317FB60B274A3851005DF3A3 /* StickerPickerCollectionViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB60A274A3850005DF3A3 /* StickerPickerCollectionViewFooter.swift */; };
+		317FB60D274A8F59005DF3A3 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB60C274A8F59005DF3A3 /* SettingsViewController.swift */; };
+		317FB60F274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */; };
+		317FB611274A9175005DF3A3 /* SettingsViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */; };
 		319C21CE273BA6D8009CE65C /* ImageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */; };
 		319C21D0273BA7D4009CE65C /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21CF273BA7D4009CE65C /* ImageRepository.swift */; };
 		319C21D8273BD764009CE65C /* URLSessionNetworkServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319C21D7273BD764009CE65C /* URLSessionNetworkServiceTest.swift */; };
@@ -160,7 +163,7 @@
 		FC9F10582730F0060060FEB7 /* GetMyIdUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9F10572730F0060060FEB7 /* GetMyIdUseCase.swift */; };
 		FC9F105B2730F1B20060FEB7 /* UserRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC9F105A2730F1B20060FEB7 /* UserRepositoryProtocol.swift */; };
 		FCC803F62744C22F00FFE4DC /* DoolDaFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC803F52744C22F00FFE4DC /* DoolDaFont.swift */; };
-		FCC803F82744FEF800FFE4DC /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC803F72744FEF800FFE4DC /* SettingViewModel.swift */; };
+		FCC803F82744FEF800FFE4DC /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC803F72744FEF800FFE4DC /* SettingsViewModel.swift */; };
 		FCC803FA27451A8000FFE4DC /* TextEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC803F927451A8000FFE4DC /* TextEditViewController.swift */; };
 		FCC803FC27451C9600FFE4DC /* TextEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC803FB27451C9600FFE4DC /* TextEditViewModel.swift */; };
 		FCCF022F273A12B400EAB00B /* EditPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCF022E273A12B400EAB00B /* EditPageViewController.swift */; };
@@ -251,6 +254,9 @@
 		3161EE99274377E300B922DD /* PackedStickerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackedStickerCollectionViewCell.swift; sourceTree = "<group>"; };
 		3161EE9B274377F400B922DD /* UnpackedStickerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnpackedStickerCollectionViewCell.swift; sourceTree = "<group>"; };
 		317FB60A274A3850005DF3A3 /* StickerPickerCollectionViewFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerPickerCollectionViewFooter.swift; sourceTree = "<group>"; };
+		317FB60C274A8F59005DF3A3 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
+		317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewCoordinatorProtocol.swift; sourceTree = "<group>"; };
+		317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewCoordinator.swift; sourceTree = "<group>"; };
 		319C21CD273BA6D8009CE65C /* ImageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryProtocol.swift; sourceTree = "<group>"; };
 		319C21CF273BA7D4009CE65C /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		319C21D5273BD764009CE65C /* URLSessionNetworkServiceTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = URLSessionNetworkServiceTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -315,7 +321,7 @@
 		FC9F10572730F0060060FEB7 /* GetMyIdUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMyIdUseCase.swift; sourceTree = "<group>"; };
 		FC9F105A2730F1B20060FEB7 /* UserRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepositoryProtocol.swift; sourceTree = "<group>"; };
 		FCC803F52744C22F00FFE4DC /* DoolDaFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoolDaFont.swift; sourceTree = "<group>"; };
-		FCC803F72744FEF800FFE4DC /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
+		FCC803F72744FEF800FFE4DC /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		FCC803F927451A8000FFE4DC /* TextEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditViewController.swift; sourceTree = "<group>"; };
 		FCC803FB27451C9600FFE4DC /* TextEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditViewModel.swift; sourceTree = "<group>"; };
 		FCCF022E273A12B400EAB00B /* EditPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPageViewController.swift; sourceTree = "<group>"; };
@@ -390,7 +396,10 @@
 		1D9FAD492747B6D400198B93 /* SettingsScene */ = {
 			isa = PBXGroup;
 			children = (
-				FCC803F72744FEF800FFE4DC /* SettingViewModel.swift */,
+				317FB60C274A8F59005DF3A3 /* SettingsViewController.swift */,
+				FCC803F72744FEF800FFE4DC /* SettingsViewModel.swift */,
+				317FB610274A9175005DF3A3 /* SettingsViewCoordinator.swift */,
+				317FB60E274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift */,
 			);
 			path = SettingsScene;
 			sourceTree = "<group>";
@@ -1030,6 +1039,7 @@
 				66F5D47A2733E88F000FB471 /* PageEntity.swift in Sources */,
 				1D8BE0792740FE5E00201E3E /* PageDocument.swift in Sources */,
 				66FE9371273671910036CED2 /* PairUserUseCase.swift in Sources */,
+				317FB611274A9175005DF3A3 /* SettingsViewCoordinator.swift in Sources */,
 				1DE5E5362738BBAA004F794F /* CoordinatorProtocol.swift in Sources */,
 				66CD645A273BE5A000E55C03 /* PhotoPickerCollectionViewCell.swift in Sources */,
 				1D3925B5273B9172003A0B70 /* DateFormatter+Extensions.swift in Sources */,
@@ -1068,16 +1078,18 @@
 				FCE9D3DE2738CFB50001F155 /* PairRepository.swift in Sources */,
 				317FB60B274A3851005DF3A3 /* StickerPickerCollectionViewFooter.swift in Sources */,
 				66FE93CC27396B960036CED2 /* PhotoPickerBottomSheetViewModel.swift in Sources */,
+				317FB60F274A915C005DF3A3 /* SettingsViewCoordinatorProtocol.swift in Sources */,
 				310125C427398DF600E43160 /* ImageUseCase.swift in Sources */,
 				66CD6450273A5C4700E55C03 /* PhotoPickerBottomSheetViewController.swift in Sources */,
 				FCD24D7C2743AAE2000203F7 /* PushNotificationStateRepositoryProtocol.swift in Sources */,
 				FC9F10582730F0060060FEB7 /* GetMyIdUseCase.swift in Sources */,
-				FCC803F82744FEF800FFE4DC /* SettingViewModel.swift in Sources */,
+				FCC803F82744FEF800FFE4DC /* SettingsViewModel.swift in Sources */,
 				1DBF5717273A328D00D28F5E /* PhotoFrameType.swift in Sources */,
 				3161EE9A274377E300B922DD /* PackedStickerCollectionViewCell.swift in Sources */,
 				3161EE942742A44100B922DD /* StickerPickerBottomSheetViewController.swift in Sources */,
 				FCC803F62744C22F00FFE4DC /* DoolDaFont.swift in Sources */,
 				FCE9D3DC2738C9A00001F155 /* PairRepositoryProtocol.swift in Sources */,
+				317FB60D274A8F59005DF3A3 /* SettingsViewController.swift in Sources */,
 				FC822FB027367AFD00C918A0 /* API.swift in Sources */,
 				FCCF022F273A12B400EAB00B /* EditPageViewController.swift in Sources */,
 				6653039B2743B3FF00E3075C /* CoreDataModel.xcdatamodeld in Sources */,

--- a/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
@@ -58,6 +58,8 @@ class DiaryViewCoordinator: DiaryViewCoordinatorProtocol {
     }
     
     func settingsPageRequested() {
+        let coordinator = SettingsViewCoordinator(presenter: self.presenter)
+        coordinator.start()
     }
     
     func filteringSheetRequested(authorFilter: DiaryAuthorFilter, orderFilter: DiaryOrderFilter) {

--- a/Doolda/Doolda/Domain/Entities/DooldaInfoType.swift
+++ b/Doolda/Doolda/Domain/Entities/DooldaInfoType.swift
@@ -1,0 +1,28 @@
+//
+//  DooldaInfoType.swift
+//  Doolda
+//
+//  Created by Dozzing on 2021/11/22.
+//
+
+import Foundation
+
+enum DooldaInfoType: String {
+    case appVersion
+    case openSourceLicense
+    case privacyPolicy
+    case contributor
+
+    var rawValue: String {
+        switch self {
+        case .appVersion:
+            return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        case .openSourceLicense:
+            return "오픈소스 라이센스"
+        case .privacyPolicy:
+            return "개인정보 처리방침"
+        case .contributor:
+            return "만든 사람들"
+        }
+    }
+}

--- a/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
@@ -87,7 +87,7 @@ class EditPageViewCoordinator: EditPageViewCoordinatorProtocol {
             delegate: delegatedViewController
         )
         
-        self.presenter.topViewController?.present(viewController, animated: false, completion: nil)
+        self.presenter.topViewController?.navigationController?.pushViewController(viewController, animated: true)
     }
     
     func addTextComponent() {

--- a/Doolda/Doolda/SettingsScene/SettingsDetailedInfoViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsDetailedInfoViewController.swift
@@ -1,5 +1,5 @@
 //
-//  SettingsOptionViewController.swift
+//  SettingsDetailedInfoViewController.swift
 //  Doolda
 //
 //  Created by Dozzing on 2021/11/22.
@@ -10,7 +10,7 @@ import UIKit
 
 import SnapKit
 
-class SettingsOptionViewController: UIViewController {
+class SettingsDetailedInfoViewController: UIViewController {
 
     // MARK: - Subviews
 

--- a/Doolda/Doolda/SettingsScene/SettingsDetailedInfoViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsDetailedInfoViewController.swift
@@ -14,25 +14,35 @@ class SettingsDetailedInfoViewController: UIViewController {
 
     // MARK: - Subviews
 
-    private lazy var scrollView: UIScrollView = {
-        let scrollView = UIScrollView()
-        return scrollView
+    private var textView: UITextView = {
+        let textView = UITextView()
+        textView.font = .systemFont(ofSize: 16)
+        textView.textColor = .dooldaLabel
+        textView.backgroundColor = .clear
+        textView.isScrollEnabled = true
+        return textView
     }()
 
-    private var contentView: UILabel = {
-        let label = UILabel()
-        label.textColor = .dooldaLabel
-        label.font = .systemFont(ofSize: 16)
-        label.textAlignment = .left
-        return label
-    }()
+    // MARK: - Public Properties
+
+    @Published var titleText: String?
+    @Published var contentText: String?
+
+    // MARK: - Private Properties
+
+    private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - Initializers
 
-    convenience init(title: String, content: String) {
+    convenience init() {
         self.init(nibName: nil, bundle: nil)
-        self.navigationItem.title = title
-        self.contentView.text = content
+        self.bindUI()
+    }
+
+    // MARK: - LifeCycle Methods
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
         self.configureUI()
     }
 
@@ -40,18 +50,28 @@ class SettingsDetailedInfoViewController: UIViewController {
 
     private func configureUI() {
         self.view.backgroundColor = .dooldaBackground
-        
-        self.view.addSubview(self.scrollView)
-        self.scrollView.snp.makeConstraints { make in
-            make.edges.equalTo(self.view.safeAreaLayoutGuide).offset(16)
-        }
 
-        self.scrollView.addSubview(self.contentView)
-        self.contentView.snp.makeConstraints { make in
-            make.top.equalTo(self.scrollView.frameLayoutGuide)
-            make.leading.equalTo(self.scrollView.frameLayoutGuide)
-            make.trailing.equalTo(self.scrollView.frameLayoutGuide)
+        self.view.addSubview(self.textView)
+        self.textView.snp.makeConstraints { make in
+            make.top.leading.equalTo(self.view.safeAreaLayoutGuide).offset(16)
+            make.bottom.trailing.equalTo(self.view.safeAreaLayoutGuide).offset(-16)
         }
+    }
+
+    private func bindUI() {
+        self.$titleText
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] title in
+                self?.navigationItem.title = title
+            }
+            .store(in: &self.cancellables)
+
+        self.$contentText
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] contentText in
+                self?.textView.text = contentText
+            }
+            .store(in: &self.cancellables)
     }
 
 }

--- a/Doolda/Doolda/SettingsScene/SettingsOptionViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsOptionViewController.swift
@@ -25,7 +25,13 @@ class SettingsOptionViewController: UIViewController {
         return scrollView
     }()
 
-    private var contentView: UIView = UIView()
+    private var contentView: UILabel = {
+        let label = UILabel()
+        label.textColor = .dooldaLabel
+        label.font = .systemFont(ofSize: 16)
+        label.textAlignment = .left
+        return label
+    }()
 
     // MARK: - Private Properties
 
@@ -33,10 +39,10 @@ class SettingsOptionViewController: UIViewController {
 
     // MARK: - Initializers
 
-    convenience init(title: String, content: UIView) {
+    convenience init(title: String, content: String) {
         self.init(nibName: nil, bundle: nil)
         self.navigationItem.title = title
-        self.contentView = contentView
+        self.contentView.text = content
         self.configureUI()
         self.bindUI()
     }
@@ -50,14 +56,14 @@ class SettingsOptionViewController: UIViewController {
 
         self.view.addSubview(self.scrollView)
         self.scrollView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.edges.equalTo(self.view.safeAreaLayoutGuide).offset(16)
         }
 
         self.scrollView.addSubview(self.contentView)
         self.contentView.snp.makeConstraints { make in
-            make.top.bottom.equalTo(self.scrollView.frameLayoutGuide)
-            make.leading.equalTo(self.scrollView.frameLayoutGuide).offset(16)
-            make.trailing.equalTo(self.scrollView.frameLayoutGuide).offset(-16)
+            make.top.equalTo(self.scrollView.frameLayoutGuide)
+            make.leading.equalTo(self.scrollView.frameLayoutGuide)
+            make.trailing.equalTo(self.scrollView.frameLayoutGuide)
         }
     }
 

--- a/Doolda/Doolda/SettingsScene/SettingsOptionViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsOptionViewController.swift
@@ -1,0 +1,58 @@
+//
+//  SettingsOptionViewController.swift
+//  Doolda
+//
+//  Created by Dozzing on 2021/11/22.
+//
+
+import UIKit
+
+import SnapKit
+
+class SettingsOptionViewController: UIViewController {
+
+    // MARK: - Subviews
+
+    private lazy var backButton: UIButton = {
+        let button = UIButton()
+        button.setImage(.left, for: .normal)
+        return button
+    }()
+
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        return scrollView
+    }()
+
+    private var contentView: UIView = UIView()
+
+    // MARK: - Initializers
+
+    convenience init(title: String, content: UIView) {
+        self.init(nibName: nil, bundle: nil)
+        self.navigationItem.title = title
+        self.contentView = contentView
+        self.configureUI()
+    }
+
+    // MARK: - Helpers
+
+    private func configureUI() {
+        self.view.backgroundColor = .dooldaBackground
+        self.navigationController?.navigationBar.barTintColor = .dooldaLabel
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: self.backButton)
+
+        self.view.addSubview(self.scrollView)
+        self.scrollView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        self.scrollView.addSubview(self.contentView)
+        self.contentView.snp.makeConstraints { make in
+            make.top.bottom.equalTo(self.scrollView.frameLayoutGuide)
+            make.leading.equalTo(self.scrollView.frameLayoutGuide).offset(16)
+            make.trailing.equalTo(self.scrollView.frameLayoutGuide).offset(-16)
+        }
+    }
+
+}

--- a/Doolda/Doolda/SettingsScene/SettingsOptionViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsOptionViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Dozzing on 2021/11/22.
 //
 
+import Combine
 import UIKit
 
 import SnapKit
@@ -26,6 +27,10 @@ class SettingsOptionViewController: UIViewController {
 
     private var contentView: UIView = UIView()
 
+    // MARK: - Private Properties
+
+    private var cancellables: Set<AnyCancellable> = []
+
     // MARK: - Initializers
 
     convenience init(title: String, content: UIView) {
@@ -33,6 +38,7 @@ class SettingsOptionViewController: UIViewController {
         self.navigationItem.title = title
         self.contentView = contentView
         self.configureUI()
+        self.bindUI()
     }
 
     // MARK: - Helpers
@@ -53,6 +59,14 @@ class SettingsOptionViewController: UIViewController {
             make.leading.equalTo(self.scrollView.frameLayoutGuide).offset(16)
             make.trailing.equalTo(self.scrollView.frameLayoutGuide).offset(-16)
         }
+    }
+
+    private func bindUI() {
+        self.backButton.publisher(for: .touchUpInside)
+            .sink { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .store(in: &self.cancellables)
     }
 
 }

--- a/Doolda/Doolda/SettingsScene/SettingsOptionViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsOptionViewController.swift
@@ -14,12 +14,6 @@ class SettingsOptionViewController: UIViewController {
 
     // MARK: - Subviews
 
-    private lazy var backButton: UIButton = {
-        let button = UIButton()
-        button.setImage(.left, for: .normal)
-        return button
-    }()
-
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         return scrollView
@@ -33,10 +27,6 @@ class SettingsOptionViewController: UIViewController {
         return label
     }()
 
-    // MARK: - Private Properties
-
-    private var cancellables: Set<AnyCancellable> = []
-
     // MARK: - Initializers
 
     convenience init(title: String, content: String) {
@@ -44,16 +34,13 @@ class SettingsOptionViewController: UIViewController {
         self.navigationItem.title = title
         self.contentView.text = content
         self.configureUI()
-        self.bindUI()
     }
 
     // MARK: - Helpers
 
     private func configureUI() {
         self.view.backgroundColor = .dooldaBackground
-        self.navigationController?.navigationBar.barTintColor = .dooldaLabel
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: self.backButton)
-
+        
         self.view.addSubview(self.scrollView)
         self.scrollView.snp.makeConstraints { make in
             make.edges.equalTo(self.view.safeAreaLayoutGuide).offset(16)
@@ -65,14 +52,6 @@ class SettingsOptionViewController: UIViewController {
             make.leading.equalTo(self.scrollView.frameLayoutGuide)
             make.trailing.equalTo(self.scrollView.frameLayoutGuide)
         }
-    }
-
-    private func bindUI() {
-        self.backButton.publisher(for: .touchUpInside)
-            .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
-            }
-            .store(in: &self.cancellables)
     }
 
 }

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
@@ -31,6 +31,13 @@ class SettingsTableViewCell: UITableViewCell {
 
     // MARK: - Initializers
 
+    convenience init(title: String, rightItem: UIView) {
+        self.init()
+        self.title.text = title
+        self.rightItem = rightItem
+        self.configureUI()
+    }
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.configureUI()

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
@@ -30,6 +30,14 @@ class SettingsTableViewCell: UITableViewCell {
         return label
     }()
 
+    private lazy var detailLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        label.textColor = .dooldaLabel
+        return label
+
+    }()
+
     // MARK: - Public Properties
 
     @Published var title: String?
@@ -63,17 +71,28 @@ class SettingsTableViewCell: UITableViewCell {
     private func configureUI() {
         self.backgroundColor = .clear
 
+        self.contentView.addSubview(self.detailLabel)
+        self.detailLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(12)
+            make.bottom.equalToSuperview().offset(-12)
+            make.trailing.equalToSuperview().offset(-16)
+            make.width.equalTo(self.detailLabel.intrinsicContentSize.width)
+        }
+
         self.contentView.addSubview(self.titleLabel)
         self.titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(12)
             make.bottom.equalToSuperview().offset(-12)
             make.leading.equalToSuperview().offset(16)
-            make.trailing.equalToSuperview().multipliedBy(0.6)
+            make.trailing.equalTo(self.detailLabel.snp.leading)
         }
 
         switch self.style {
         case .disclosure:
             self.accessoryType = .disclosureIndicator
+            self.detailLabel.isHidden = true
+        case .detail:
+            self.detailLabel.isHidden = false
         default: return
         }
     }
@@ -83,6 +102,16 @@ class SettingsTableViewCell: UITableViewCell {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] title in
                 self?.titleLabel.text = title
+            }
+            .store(in: &self.cancellables)
+
+        self.$detailText
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] detailText in
+                self?.detailLabel.text = detailText
+                self?.detailLabel.snp.updateConstraints { make in
+                    make.width.equalTo(self?.detailLabel.intrinsicContentSize.width ?? 0)
+                }
             }
             .store(in: &self.cancellables)
     }

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
@@ -13,7 +13,7 @@ import SnapKit
 class SettingsTableViewCell: UITableViewCell {
 
     enum Style {
-        case detail, disclosure
+        case detail, disclosure, switchButton
     }
 
     // MARK: - Static Properties
@@ -24,7 +24,6 @@ class SettingsTableViewCell: UITableViewCell {
 
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 16)
         label.textColor = .dooldaLabel
         label.text = "title"
         return label
@@ -32,7 +31,6 @@ class SettingsTableViewCell: UITableViewCell {
 
     private lazy var detailLabel: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 16)
         label.textColor = .dooldaLabel
         return label
 
@@ -97,6 +95,11 @@ class SettingsTableViewCell: UITableViewCell {
         }
     }
 
+    private func configureFont() {
+        self.titleLabel.font = self.font
+        self.detailLabel.font = self.font
+    }
+
     private func bindUI() {
         self.$title
             .receive(on: DispatchQueue.main)
@@ -112,6 +115,13 @@ class SettingsTableViewCell: UITableViewCell {
                 self?.detailLabel.snp.updateConstraints { make in
                     make.width.equalTo(self?.detailLabel.intrinsicContentSize.width ?? 0)
                 }
+            }
+            .store(in: &self.cancellables)
+
+        self.$font
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.configureFont()
             }
             .store(in: &self.cancellables)
     }

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
@@ -42,17 +42,28 @@ class SettingsTableViewCell: UITableViewCell {
     // MARK: - Helpers
 
     private func configureUI() {
+        self.backgroundColor = .clear
+
         self.contentView.addSubview(self.title)
         self.title.snp.makeConstraints { make in
-            make.top.leading.bottom.equalToSuperview()
+            make.top.bottom.equalToSuperview()
+            make.leading.equalToSuperview().offset(10)
             make.width.equalToSuperview().multipliedBy(0.6)
         }
 
         self.contentView.addSubview(self.rightItem)
         self.rightItem.snp.makeConstraints { make in
-            make.top.trailing.bottom.equalToSuperview()
-            make.leading.equalTo(self.title)
+            make.top.bottom.equalToSuperview()
+            make.trailing.equalToSuperview().offset(-10)
+            make.leading.equalTo(self.title.snp.trailing)
         }
+    }
+
+    // MARK: - Public Methods
+
+    func configure(title: String, rightItem: UIView) {
+        self.title.text = title
+        self.rightItem = rightItem
     }
 
 }

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
@@ -1,0 +1,58 @@
+//
+//  SettingsTableViewCell.swift
+//  Doolda
+//
+//  Created by Dozzing on 2021/11/22.
+//
+
+import UIKit
+
+import SnapKit
+
+class SettingsTableViewCell: UITableViewCell {
+
+    // MARK: - Static Properties
+
+    static let identifier = "SettingsTableViewCell"
+
+    // MARK: - Subviews
+
+    private lazy var title: UILabel = {
+        let label = UILabel()
+        return label
+    }()
+
+    private lazy var rightItem: UIView = {
+        let item = UIView()
+        return item
+    }()
+
+    // MARK: - Initializers
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.configureUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configureUI()
+    }
+
+    // MARK: - Helpers
+
+    private func configureUI() {
+        self.contentView.addSubview(self.title)
+        self.title.snp.makeConstraints { make in
+            make.top.leading.bottom.equalToSuperview()
+            make.width.equalToSuperview().multipliedBy(0.6)
+        }
+
+        self.contentView.addSubview(self.rightItem)
+        self.rightItem.snp.makeConstraints { make in
+            make.top.trailing.bottom.equalToSuperview()
+            make.leading.equalTo(self.title)
+        }
+    }
+
+}

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
@@ -64,12 +64,5 @@ class SettingsTableViewCell: UITableViewCell {
             make.trailing.equalTo(self.rightItem.snp.leading)
         }
     }
-
-    // MARK: - Public Methods
-
-    func configure(title: String, rightItem: UIView) {
-        self.title.text = title
-        self.rightItem = rightItem
-    }
-
+    
 }

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
@@ -5,11 +5,16 @@
 //  Created by Dozzing on 2021/11/22.
 //
 
+import Combine
 import UIKit
 
 import SnapKit
 
 class SettingsTableViewCell: UITableViewCell {
+
+    enum Style {
+        case detail, disclosure
+    }
 
     // MARK: - Static Properties
 
@@ -17,22 +22,32 @@ class SettingsTableViewCell: UITableViewCell {
 
     // MARK: - Subviews
 
-    private lazy var title: UILabel = {
+    private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16)
         label.textColor = .dooldaLabel
+        label.text = "title"
         return label
     }()
 
-    private var rightItem: UIView = UIView()
+    // MARK: - Public Properties
+
+    @Published var title: String?
+    @Published var detailText: String?
+    @Published var font: UIFont?
+
+    // MARK: - Private Properties
+
+    private var style: Style?
+    private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - Initializers
 
-    convenience init(title: String, rightItem: UIView) {
+    convenience init(style: Style) {
         self.init()
-        self.title.text = title
-        self.rightItem = rightItem
+        self.style = style
         self.configureUI()
+        self.bindUI()
     }
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -48,21 +63,28 @@ class SettingsTableViewCell: UITableViewCell {
     private func configureUI() {
         self.backgroundColor = .clear
 
-        self.contentView.addSubview(self.rightItem)
-        self.rightItem.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(12)
-            make.bottom.equalToSuperview().offset(-12)
-            make.trailing.equalToSuperview().offset(-16)
-            make.width.equalTo(self.rightItem.intrinsicContentSize.width)
-        }
-
-        self.contentView.addSubview(self.title)
-        self.title.snp.makeConstraints { make in
+        self.contentView.addSubview(self.titleLabel)
+        self.titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(12)
             make.bottom.equalToSuperview().offset(-12)
             make.leading.equalToSuperview().offset(16)
-            make.trailing.equalTo(self.rightItem.snp.leading)
+            make.trailing.equalToSuperview().multipliedBy(0.6)
         }
+
+        switch self.style {
+        case .disclosure:
+            self.accessoryType = .disclosureIndicator
+        default: return
+        }
+    }
+
+    private func bindUI() {
+        self.$title
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] title in
+                self?.titleLabel.text = title
+            }
+            .store(in: &self.cancellables)
     }
     
 }

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
@@ -24,10 +24,7 @@ class SettingsTableViewCell: UITableViewCell {
         return label
     }()
 
-    private lazy var rightItem: UIView = {
-        let item = UIView()
-        return item
-    }()
+    private var rightItem: UIView = UIView()
 
     // MARK: - Initializers
 
@@ -53,19 +50,20 @@ class SettingsTableViewCell: UITableViewCell {
     private func configureUI() {
         self.backgroundColor = .clear
 
+        self.contentView.addSubview(self.rightItem)
+        self.rightItem.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(12)
+            make.bottom.equalToSuperview().offset(-12)
+            make.trailing.equalToSuperview().offset(-16)
+            make.width.equalTo(self.rightItem.intrinsicContentSize.width)
+        }
+
         self.contentView.addSubview(self.title)
         self.title.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(12)
             make.bottom.equalToSuperview().offset(-12)
             make.leading.equalToSuperview().offset(16)
-            make.width.equalToSuperview().multipliedBy(0.6)
-        }
-
-        self.contentView.addSubview(self.rightItem)
-        self.rightItem.snp.makeConstraints { make in
-            make.top.bottom.equalTo(self.title)
-            make.trailing.equalToSuperview().offset(-16)
-            make.leading.equalTo(self.title.snp.trailing)
+            make.trailing.equalTo(self.rightItem.snp.leading)
         }
     }
 

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
@@ -19,6 +19,8 @@ class SettingsTableViewCell: UITableViewCell {
 
     private lazy var title: UILabel = {
         let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        label.textColor = .dooldaLabel
         return label
     }()
 
@@ -46,15 +48,16 @@ class SettingsTableViewCell: UITableViewCell {
 
         self.contentView.addSubview(self.title)
         self.title.snp.makeConstraints { make in
-            make.top.bottom.equalToSuperview()
-            make.leading.equalToSuperview().offset(10)
+            make.top.equalToSuperview().offset(12)
+            make.bottom.equalToSuperview().offset(-12)
+            make.leading.equalToSuperview().offset(16)
             make.width.equalToSuperview().multipliedBy(0.6)
         }
 
         self.contentView.addSubview(self.rightItem)
         self.rightItem.snp.makeConstraints { make in
-            make.top.bottom.equalToSuperview()
-            make.trailing.equalToSuperview().offset(-10)
+            make.top.bottom.equalTo(self.title)
+            make.trailing.equalToSuperview().offset(-16)
             make.leading.equalTo(self.title.snp.trailing)
         }
     }

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewCell.swift
@@ -37,12 +37,10 @@ class SettingsTableViewCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        self.configureUI()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        self.configureUI()
     }
 
     // MARK: - Helpers

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewHeader.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewHeader.swift
@@ -5,6 +5,7 @@
 //  Created by Dozzing on 2021/11/22.
 //
 
+import Combine
 import UIKit
 
 import SnapKit
@@ -17,12 +18,21 @@ class SettingsTableViewHeader: UITableViewHeaderFooterView {
 
     // MARK: - Subviews
 
-    private lazy var title: UILabel = {
+    private lazy var titleLabel: UILabel = {
         let title = UILabel()
         title.font = .systemFont(ofSize: 16)
         title.textColor = .dooldaSubLabel
         return title
     }()
+
+    // MARK: - Public Properties
+
+    @Published var title: String?
+    @Published var font: UIFont?
+
+    // MARK: - Private Properties
+
+    private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - Initializers
 
@@ -39,8 +49,8 @@ class SettingsTableViewHeader: UITableViewHeaderFooterView {
     // MARK: - Helpers
 
     private func configureUI() {
-        self.addSubview(title)
-        self.title.snp.makeConstraints { make in
+        self.addSubview(titleLabel)
+        self.titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(16)
             make.bottom.equalToSuperview().offset(-16)
             make.leading.equalToSuperview().offset(16)
@@ -48,10 +58,24 @@ class SettingsTableViewHeader: UITableViewHeaderFooterView {
         }
     }
 
-    // MARK: - Public Methods
+    private func configureFont() {
+        self.titleLabel.font = self.font
+    }
 
-    func configure(with title: String) {
-        self.title.text = title
+    private func bindUI() {
+        self.$title
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] title in
+                self?.titleLabel.text = title
+            }
+            .store(in: &self.cancellables)
+
+        self.$font
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.configureFont()
+            }
+            .store(in: &self.cancellables)
     }
 
 }

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewHeader.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewHeader.swift
@@ -17,7 +17,7 @@ class SettingsTableViewHeader: UITableViewHeaderFooterView {
 
     // MARK: - Subviews
 
-    lazy var title: UILabel = {
+    private lazy var title: UILabel = {
         let title = UILabel()
         title.font = .systemFont(ofSize: 16)
         title.textColor = .dooldaSubLabel
@@ -43,6 +43,7 @@ class SettingsTableViewHeader: UITableViewHeaderFooterView {
         self.title.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(16)
             make.bottom.equalToSuperview().offset(-16)
+            make.leading.equalToSuperview().offset(16)
             make.width.equalToSuperview()
         }
     }

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewHeader.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewHeader.swift
@@ -1,0 +1,56 @@
+//
+//  SettingsTableViewHeader.swift
+//  Doolda
+//
+//  Created by Dozzing on 2021/11/22.
+//
+
+import UIKit
+
+import SnapKit
+
+class SettingsTableViewHeader: UITableViewHeaderFooterView {
+
+    // MARK: - Static Properties
+
+    static let identifier = "SettingsTableViewHeader"
+
+    // MARK: - Subviews
+
+    lazy var title: UILabel = {
+        let title = UILabel()
+        title.font = .systemFont(ofSize: 16)
+        title.textColor = .dooldaSubLabel
+        return title
+    }()
+
+    // MARK: - Initializers
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        self.configureUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configureUI()
+    }
+
+    // MARK: - Helpers
+
+    private func configureUI() {
+        self.addSubview(title)
+        self.title.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(16)
+            make.bottom.equalToSuperview().offset(-16)
+            make.width.equalToSuperview()
+        }
+    }
+
+    // MARK: - Public Methods
+
+    func configure(with title: String) {
+        self.title.text = title
+    }
+
+}

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -111,7 +111,10 @@ class SettingsViewController: UIViewController {
     }
 
     private func configureFont() {
-        self.settingsSections.forEach { section in
+        self.settingsSections.enumerated().forEach { index, section in
+            guard let header = self.tableView.headerView(forSection: index) as? SettingsTableViewHeader else { return }
+            header.font = .systemFont(ofSize: 16)
+
             section.settingsOptions.forEach { options in
                 options.cell.font = .systemFont(ofSize: 16)
             }
@@ -142,7 +145,7 @@ extension SettingsViewController: UITableViewDataSource {
                 withIdentifier: SettingsTableViewHeader.identifier
               ) as? SettingsTableViewHeader else { return nil }
 
-        header.configure(with: self.settingsSections[section].title)
+        header.title = self.settingsSections[section].title
         return header
     }
 

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -19,7 +19,7 @@ class SettingsViewController: UIViewController {
 
     struct SettingsOptions {
         let cell: UITableViewCell
-        let handler: (() -> ())?
+        let handler: (() -> Void)?
     }
 
     // MARK: - Subviews
@@ -135,21 +135,21 @@ extension SettingsViewController: UITableViewDelegate {
 
 extension SettingsViewController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 2
+        return self.settingsSections.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 3
+        guard section < self.settingsSections.count else { return 0 }
+        return  self.settingsSections[section].settingsOptions.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // FIXME: ViewModel로부터 indexPath의 타이틀 정보, 우측 텍스트 정보를 받아와야 함
-        guard let cell = tableView.dequeueReusableCell(
-            withIdentifier: SettingsTableViewCell.identifier,
-            for: indexPath
-        ) as? SettingsTableViewCell else { return UITableViewCell() }
-        let rightItem = UIImageView(image: .right)
-        cell.configure(title: "설정", rightItem: rightItem)
-        return cell
+        guard indexPath.section < self.settingsSections.count else { return UITableViewCell() }
+
+        let section = self.settingsSections[indexPath.section]
+        guard indexPath.row < section.settingsOptions.count else { return UITableViewCell() }
+
+        let settingsOption = section.settingsOptions
+        return settingsOption[indexPath.row].cell
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -12,6 +12,16 @@ import SnapKit
 
 class SettingsViewController: UIViewController {
 
+    struct SettingsSection {
+        let title: String
+        var settingsOptions: [SettingsOptions]
+    }
+
+    struct SettingsOptions {
+        let cell: UITableViewCell
+        let handler: () -> ()
+    }
+
     // MARK: - Subviews
 
     private lazy var backButton: UIButton = {
@@ -35,6 +45,14 @@ class SettingsViewController: UIViewController {
 
     private var viewModel: SettingsViewModelProtocol!
     private var cancellables: Set<AnyCancellable> = []
+
+    private lazy var settingsSections: [SettingsSection] = {
+        var sections: [SettingsSection] = []
+
+        
+
+        return sections
+    }()
 
     // MARK: - Initializers
 

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -110,9 +110,12 @@ class SettingsViewController: UIViewController {
     private func configureUI() {
         self.view.backgroundColor = .dooldaBackground
         self.title = "설정"
+
         self.navigationController?.isNavigationBarHidden = false
         self.navigationController?.navigationBar.tintColor = .dooldaLabel
         self.navigationController?.navigationBar.topItem?.title = ""
+        self.navigationItem.backButtonTitle = ""
+
         self.view.addSubview(self.tableView)
         self.tableView.snp.makeConstraints { make in
             make.edges.equalToSuperview()

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -24,10 +24,16 @@ class SettingsViewController: UIViewController {
         let tableView = UITableView()
         tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: SettingsTableViewCell.identifier)
         tableView.backgroundColor = .clear
+        tableView.separatorColor = .dooldaLabel?.withAlphaComponent(0.5)
+        tableView.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         tableView.delegate = self
         tableView.dataSource = self
         return tableView
     }()
+
+    // MARK: - Private Properties
+
+    private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - LifeCycle Methods
 
@@ -50,10 +56,18 @@ class SettingsViewController: UIViewController {
         }
     }
 
+    private func bindUI() {
+        self.backButton.publisher(for: .touchUpInside)
+            .sink { [weak self] _ in
+                
+            }
+            .store(in: &self.cancellables)
+    }
+
 }
 
 extension SettingsViewController: UITableViewDelegate {
-
+   
 }
 
 extension SettingsViewController: UITableViewDataSource {

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -19,7 +19,7 @@ class SettingsViewController: UIViewController {
 
     struct SettingsOptions {
         let cell: UITableViewCell
-        let handler: () -> ()
+        let handler: (() -> ())?
     }
 
     // MARK: - Subviews
@@ -47,10 +47,46 @@ class SettingsViewController: UIViewController {
     private var cancellables: Set<AnyCancellable> = []
 
     private lazy var settingsSections: [SettingsSection] = {
-        var sections: [SettingsSection] = []
+        let alertOption = SettingsOptions(
+            cell: SettingsTableViewCell(title: "푸시 알림 허용", rightItem: UILabel()),
+            handler: nil
+        )
 
-        //let alertOption = SettingsOptions(cell: <#T##UITableViewCell#>, handler: <#T##() -> ()#>)
+        let fontOption = SettingsOptions(
+            cell: SettingsTableViewCell(title: "폰트 설정", rightItem: UILabel()),
+            handler: nil
+        )
 
+        let appVersionLabel = UILabel()
+        appVersionLabel.text = DooldaInfoType.appVersion.rawValue
+        let appVersionOption = SettingsOptions(
+            cell: SettingsTableViewCell(title: "앱 현재 버전", rightItem: appVersionLabel),
+            handler: nil
+        )
+
+        let forwardImageView = UIImageView(image: .right)
+        let openSourceOption = SettingsOptions(
+            cell: SettingsTableViewCell(title: "Open Source License", rightItem: forwardImageView),
+            handler: self.viewModel.openSourceLicenseDidTap
+        )
+
+        let privacyOption = SettingsOptions(
+            cell: SettingsTableViewCell(title: "개인 정보 처리 방침", rightItem: forwardImageView),
+            handler: self.viewModel.privacyPolicyDidTap
+        )
+
+        let contributorsOption = SettingsOptions(
+            cell: SettingsTableViewCell(title: "만든 사람들", rightItem: forwardImageView),
+            handler: self.viewModel.contributorDidTap
+        )
+
+        let appSection = SettingsSection(title: "앱 설정", settingsOptions: [alertOption, fontOption])
+        let serviceSection = SettingsSection(
+            title: "서비스 정보",
+            settingsOptions: [appVersionOption, openSourceOption, privacyOption, contributorsOption]
+        )
+
+        let sections: [SettingsSection] = [appSection, serviceSection]
         return sections
     }()
 

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -150,6 +150,14 @@ extension SettingsViewController: UITableViewDataSource {
         return  self.settingsSections[section].settingsOptions.count
     }
 
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard section < self.settingsSections.count else { return UIView() }
+        let header = UILabel()
+        header.text = self.settingsSections[section].title
+        header.textColor = .dooldaSubLabel
+        return header
+    }
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard indexPath.section < self.settingsSections.count else { return UITableViewCell() }
 

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -10,24 +10,19 @@ import UIKit
 
 import SnapKit
 
-struct SettingsOption {
-    let title: String
-    let rightButtonItem: UIView
-    let handler: (() -> Void)
-}
-
 class SettingsViewController: UIViewController {
 
     // MARK: - Subviews
 
     private lazy var backButton: UIButton = {
         let button = UIButton()
-        button.setImage(.back, for: .normal)
+        button.setImage(.left, for: .normal)
         return button
     }()
 
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
+        tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: SettingsTableViewCell.identifier)
         tableView.backgroundColor = .clear
         tableView.delegate = self
         tableView.dataSource = self
@@ -71,6 +66,13 @@ extension SettingsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return UITableViewCell()
+        // FIXME: ViewModel로부터 indexPath의 타이틀 정보, 우측 텍스트 정보를 받아와야 함
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: SettingsTableViewCell.identifier,
+            for: indexPath
+        ) as? SettingsTableViewCell else { return UITableViewCell() }
+        let rightItem = UIImageView(image: .right)
+        cell.configure(title: "설정", rightItem: rightItem)
+        return cell
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -33,9 +33,9 @@ class SettingsViewController: UIViewController {
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: SettingsTableViewCell.identifier)
+        tableView.register(SettingsTableViewHeader.self, forHeaderFooterViewReuseIdentifier: SettingsTableViewHeader.identifier)
         tableView.backgroundColor = .clear
-        tableView.separatorColor = .dooldaLabel?.withAlphaComponent(0.5)
-        tableView.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        tableView.separatorStyle = .none
         tableView.isScrollEnabled = false
         tableView.delegate = self
         tableView.dataSource = self
@@ -151,10 +151,12 @@ extension SettingsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard section < self.settingsSections.count else { return UIView() }
-        let header = UILabel()
-        header.text = self.settingsSections[section].title
-        header.textColor = .dooldaSubLabel
+        guard section < self.settingsSections.count,
+              let header = tableView.dequeueReusableHeaderFooterView(
+                withIdentifier: SettingsTableViewHeader.identifier
+              ) as? SettingsTableViewHeader else { return nil }
+
+        header.configure(with: self.settingsSections[section].title)
         return header
     }
 
@@ -164,7 +166,13 @@ extension SettingsViewController: UITableViewDataSource {
         let section = self.settingsSections[indexPath.section]
         guard indexPath.row < section.settingsOptions.count else { return UITableViewCell() }
 
-        let settingsOption = section.settingsOptions
-        return settingsOption[indexPath.row].cell
+        let cell = section.settingsOptions[indexPath.row].cell
+
+        let separator = CALayer()
+        separator.frame = CGRect(x: 16, y: cell.frame.height - 1, width: self.tableView.frame.width-32, height: 1)
+        separator.backgroundColor = UIColor.dooldaLabel?.withAlphaComponent(0.2).cgColor
+        cell.layer.addSublayer(separator)
+        cell.selectionStyle = .none
+        return cell
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -24,12 +24,6 @@ class SettingsViewController: UIViewController {
 
     // MARK: - Subviews
 
-    private lazy var backButton: UIButton = {
-        let button = UIButton()
-        button.setImage(.left, for: .normal)
-        return button
-    }()
-
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.register(SettingsTableViewCell.self, forCellReuseIdentifier: SettingsTableViewCell.identifier)
@@ -109,7 +103,6 @@ class SettingsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureUI()
-        self.bindUI()
     }
 
     // MARK: - Helpers
@@ -117,21 +110,13 @@ class SettingsViewController: UIViewController {
     private func configureUI() {
         self.view.backgroundColor = .dooldaBackground
         self.title = "설정"
-        self.navigationController?.navigationBar.barTintColor = .dooldaLabel
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: self.backButton)
-
+        self.navigationController?.isNavigationBarHidden = false
+        self.navigationController?.navigationBar.tintColor = .dooldaLabel
+        self.navigationController?.navigationBar.topItem?.title = ""
         self.view.addSubview(self.tableView)
         self.tableView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
-    }
-
-    private func bindUI() {
-        self.backButton.publisher(for: .touchUpInside)
-            .sink { [weak self] _ in
-                self?.viewModel.backButtonDidTap()
-            }
-            .store(in: &self.cancellables)
     }
 
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -36,6 +36,7 @@ class SettingsViewController: UIViewController {
         tableView.backgroundColor = .clear
         tableView.separatorColor = .dooldaLabel?.withAlphaComponent(0.5)
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        tableView.isScrollEnabled = false
         tableView.delegate = self
         tableView.dataSource = self
         return tableView
@@ -59,24 +60,30 @@ class SettingsViewController: UIViewController {
 
         let appVersionLabel = UILabel()
         appVersionLabel.text = DooldaInfoType.appVersion.rawValue
+        appVersionLabel.textColor = .dooldaLabel
         let appVersionOption = SettingsOptions(
             cell: SettingsTableViewCell(title: "앱 현재 버전", rightItem: appVersionLabel),
             handler: nil
         )
 
-        let forwardImageView = UIImageView(image: .right)
+        let openSourceItem = UIImageView(image: .right)
+        openSourceItem.tintColor = .dooldaLabel
         let openSourceOption = SettingsOptions(
-            cell: SettingsTableViewCell(title: "Open Source License", rightItem: forwardImageView),
+            cell: SettingsTableViewCell(title: "Open Source License", rightItem: openSourceItem),
             handler: self.viewModel.openSourceLicenseDidTap
         )
 
+        let privacyItem = UIImageView(image: .right)
+        privacyItem.tintColor = .dooldaLabel
         let privacyOption = SettingsOptions(
-            cell: SettingsTableViewCell(title: "개인 정보 처리 방침", rightItem: forwardImageView),
+            cell: SettingsTableViewCell(title: "개인 정보 처리 방침", rightItem: privacyItem),
             handler: self.viewModel.privacyPolicyDidTap
         )
 
+        let contributorItem = UIImageView(image: .right)
+        contributorItem.tintColor = .dooldaLabel
         let contributorsOption = SettingsOptions(
-            cell: SettingsTableViewCell(title: "만든 사람들", rightItem: forwardImageView),
+            cell: SettingsTableViewCell(title: "만든 사람들", rightItem: contributorItem),
             handler: self.viewModel.contributorDidTap
         )
 

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -49,7 +49,7 @@ class SettingsViewController: UIViewController {
     private lazy var settingsSections: [SettingsSection] = {
         var sections: [SettingsSection] = []
 
-        
+        //let alertOption = SettingsOptions(cell: <#T##UITableViewCell#>, handler: <#T##() -> ()#>)
 
         return sections
     }()

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -42,44 +42,30 @@ class SettingsViewController: UIViewController {
     private var cancellables: Set<AnyCancellable> = []
 
     private lazy var settingsSections: [SettingsSection] = {
-        let alertOption = SettingsOptions(
-            cell: SettingsTableViewCell(title: "푸시 알림 허용", rightItem: UILabel()),
-            handler: nil
-        )
+        let alertCell = SettingsTableViewCell(style: .disclosure)
+        alertCell.title = "푸시 알림 허용"
+        let alertOption = SettingsOptions(cell: alertCell, handler: nil)
 
-        let fontOption = SettingsOptions(
-            cell: SettingsTableViewCell(title: "폰트 설정", rightItem: UILabel()),
-            handler: nil
-        )
+        let fontCell = SettingsTableViewCell(style: .disclosure)
+        fontCell.title = "폰트 설정"
+        let fontOption = SettingsOptions(cell: fontCell, handler: nil)
 
-        let appVersionLabel = UILabel()
-        appVersionLabel.text = DooldaInfoType.appVersion.rawValue
-        appVersionLabel.textColor = .dooldaLabel
-        let appVersionOption = SettingsOptions(
-            cell: SettingsTableViewCell(title: "앱 현재 버전", rightItem: appVersionLabel),
-            handler: nil
-        )
+        let versionCell = SettingsTableViewCell(style: .detail)
+        versionCell.title = "앱 현재 버전"
+        versionCell.detailText = DooldaInfoType.appVersion.rawValue
+        let appVersionOption = SettingsOptions(cell: versionCell, handler: nil)
 
-        let openSourceItem = UIImageView(image: .right)
-        openSourceItem.tintColor = .dooldaLabel
-        let openSourceOption = SettingsOptions(
-            cell: SettingsTableViewCell(title: "Open Source License", rightItem: openSourceItem),
-            handler: self.viewModel.openSourceLicenseDidTap
-        )
+        let openSourceCell = SettingsTableViewCell(style: .disclosure)
+        openSourceCell.title = "Open Source License"
+        let openSourceOption = SettingsOptions(cell: openSourceCell, handler: self.viewModel.openSourceLicenseDidTap)
 
-        let privacyItem = UIImageView(image: .right)
-        privacyItem.tintColor = .dooldaLabel
-        let privacyOption = SettingsOptions(
-            cell: SettingsTableViewCell(title: "개인 정보 처리 방침", rightItem: privacyItem),
-            handler: self.viewModel.privacyPolicyDidTap
-        )
+        let privacyCell = SettingsTableViewCell(style: .disclosure)
+        privacyCell.title = "개인 정보 처리 방침"
+        let privacyOption = SettingsOptions(cell: privacyCell, handler: self.viewModel.privacyPolicyDidTap)
 
-        let contributorItem = UIImageView(image: .right)
-        contributorItem.tintColor = .dooldaLabel
-        let contributorsOption = SettingsOptions(
-            cell: SettingsTableViewCell(title: "만든 사람들", rightItem: contributorItem),
-            handler: self.viewModel.contributorDidTap
-        )
+        let contributorCell = SettingsTableViewCell(style: .disclosure)
+        contributorCell.title = "만든 사람들"
+        let contributorsOption = SettingsOptions(cell: contributorCell, handler: self.viewModel.contributorDidTap)
 
         let appSection = SettingsSection(title: "앱 설정", settingsOptions: [alertOption, fontOption])
         let serviceSection = SettingsSection(

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -1,0 +1,19 @@
+//
+//  SettingsViewController.swift
+//  Doolda
+//
+//  Created by Dozzing on 2021/11/21.
+//
+
+import Combine
+import UIKit
+
+import SnapKit
+
+class SettingsViewController: UIViewController {
+
+    override func viewDidLoad() {
+        self.view.backgroundColor = .dooldaBackground
+    }
+
+}

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -137,7 +137,13 @@ class SettingsViewController: UIViewController {
 }
 
 extension SettingsViewController: UITableViewDelegate {
-   
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard indexPath.section < self.settingsSections.count else { return }
+        let section = self.settingsSections[indexPath.section]
+        guard indexPath.row < section.settingsOptions.count,
+              let handler = section.settingsOptions[indexPath.row].handler else { return }
+        handler()
+    }
 }
 
 extension SettingsViewController: UITableViewDataSource {

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -33,13 +33,22 @@ class SettingsViewController: UIViewController {
 
     // MARK: - Private Properties
 
+    private var viewModel: SettingsViewModelProtocol!
     private var cancellables: Set<AnyCancellable> = []
+
+    // MARK: - Initializers
+
+    convenience init(viewModel: SettingsViewModelProtocol) {
+        self.init(nibName: nil, bundle: nil)
+        self.viewModel = viewModel
+    }
 
     // MARK: - LifeCycle Methods
 
     override func viewDidLoad() {
         super.viewDidLoad()
         self.configureUI()
+        self.bindUI()
     }
 
     // MARK: - Helpers
@@ -59,7 +68,7 @@ class SettingsViewController: UIViewController {
     private func bindUI() {
         self.backButton.publisher(for: .touchUpInside)
             .sink { [weak self] _ in
-                
+                self?.viewModel.backButtonDidTap()
             }
             .store(in: &self.cancellables)
     }

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -10,6 +10,12 @@ import UIKit
 
 import SnapKit
 
+struct SettingsOption {
+    let title: String
+    let rightButtonItem: UIView
+    let handler: (() -> Void)
+}
+
 class SettingsViewController: UIViewController {
 
     // MARK: - Subviews

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -126,10 +126,8 @@ class SettingsViewController: UIViewController {
 
 extension SettingsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard indexPath.section < self.settingsSections.count else { return }
-        let section = self.settingsSections[indexPath.section]
-        guard indexPath.row < section.settingsOptions.count,
-              let handler = section.settingsOptions[indexPath.row].handler else { return }
+        guard let section = self.settingsSections[exist: indexPath.section],
+              let handler = section.settingsOptions[exist: indexPath.row]?.handler else { return }
         handler()
     }
 }
@@ -140,13 +138,11 @@ extension SettingsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard section < self.settingsSections.count else { return 0 }
-        return  self.settingsSections[section].settingsOptions.count
+        return self.settingsSections[exist: section]?.settingsOptions.count ?? 0
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard section < self.settingsSections.count,
-              let header = tableView.dequeueReusableHeaderFooterView(
+        guard let header = tableView.dequeueReusableHeaderFooterView(
                 withIdentifier: SettingsTableViewHeader.identifier
               ) as? SettingsTableViewHeader else { return nil }
 
@@ -155,12 +151,8 @@ extension SettingsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard indexPath.section < self.settingsSections.count else { return UITableViewCell() }
-
-        let section = self.settingsSections[indexPath.section]
-        guard indexPath.row < section.settingsOptions.count else { return UITableViewCell() }
-
-        let cell = section.settingsOptions[indexPath.row].cell
+        guard let section = self.settingsSections[exist: indexPath.section],
+              let cell = section.settingsOptions[exist: indexPath.row]?.cell else { return UITableViewCell() }
 
         let separator = CALayer()
         separator.frame = CGRect(x: 16, y: cell.frame.height - 1, width: self.tableView.frame.width-32, height: 1)

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -18,7 +18,7 @@ class SettingsViewController: UIViewController {
     }
 
     struct SettingsOptions {
-        let cell: UITableViewCell
+        let cell: SettingsTableViewCell
         let handler: (() -> Void)?
     }
 
@@ -36,17 +36,12 @@ class SettingsViewController: UIViewController {
         return tableView
     }()
 
-    // MARK: - Private Properties
-
-    private var viewModel: SettingsViewModelProtocol!
-    private var cancellables: Set<AnyCancellable> = []
-
     private lazy var settingsSections: [SettingsSection] = {
-        let alertCell = SettingsTableViewCell(style: .disclosure)
+        let alertCell = SettingsTableViewCell(style: .detail)
         alertCell.title = "푸시 알림 허용"
         let alertOption = SettingsOptions(cell: alertCell, handler: nil)
 
-        let fontCell = SettingsTableViewCell(style: .disclosure)
+        let fontCell = SettingsTableViewCell(style: .detail)
         fontCell.title = "폰트 설정"
         let fontOption = SettingsOptions(cell: fontCell, handler: nil)
 
@@ -77,6 +72,11 @@ class SettingsViewController: UIViewController {
         return sections
     }()
 
+    // MARK: - Private Properties
+
+    private var viewModel: SettingsViewModelProtocol!
+    private var cancellables: Set<AnyCancellable> = []
+
     // MARK: - Initializers
 
     convenience init(viewModel: SettingsViewModelProtocol) {
@@ -105,6 +105,16 @@ class SettingsViewController: UIViewController {
         self.view.addSubview(self.tableView)
         self.tableView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+
+        self.configureFont()
+    }
+
+    private func configureFont() {
+        self.settingsSections.forEach { section in
+            section.settingsOptions.forEach { options in
+                options.cell.font = .systemFont(ofSize: 16)
+            }
         }
     }
 

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -20,6 +20,14 @@ class SettingsViewController: UIViewController {
         return button
     }()
 
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.backgroundColor = .clear
+        tableView.delegate = self
+        tableView.dataSource = self
+        return tableView
+    }()
+
     // MARK: - LifeCycle Methods
 
     override func viewDidLoad() {
@@ -34,6 +42,29 @@ class SettingsViewController: UIViewController {
         self.title = "설정"
         self.navigationController?.navigationBar.barTintColor = .dooldaLabel
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: self.backButton)
+
+        self.view.addSubview(self.tableView)
+        self.tableView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
     }
 
+}
+
+extension SettingsViewController: UITableViewDelegate {
+
+}
+
+extension SettingsViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 2
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 3
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        return UITableViewCell()
+    }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -12,8 +12,28 @@ import SnapKit
 
 class SettingsViewController: UIViewController {
 
+    // MARK: - Subviews
+
+    private lazy var backButton: UIButton = {
+        let button = UIButton()
+        button.setImage(.back, for: .normal)
+        return button
+    }()
+
+    // MARK: - LifeCycle Methods
+
     override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureUI()
+    }
+
+    // MARK: - Helpers
+
+    private func configureUI() {
         self.view.backgroundColor = .dooldaBackground
+        self.title = "설정"
+        self.navigationController?.navigationBar.barTintColor = .dooldaLabel
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: self.backButton)
     }
 
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -41,7 +41,10 @@ class SettingsViewCoordinator: SettingsViewCoordinatorProtocol {
         }
     }
 
-    func settingsOptionRequested(with text: String) {
-
+    func settingsOptionRequested(title: String ,text: String) {
+        let label = UILabel()
+        label.text = text
+        let viewController = SettingsOptionViewController(title: title, content: label)
+        self.presenter.topViewController?.navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -16,16 +16,32 @@ class SettingsViewCoordinator: SettingsViewCoordinatorProtocol {
 
     func start() {
         DispatchQueue.main.async {
-            let viewController = SettingsViewController()
+            let userDefaultsPersistenceService = UserDefaultsPersistenceService()
+
+            let globalFontRepository = GlobalFontRepository(persistenceService: userDefaultsPersistenceService)
+            let pushNotificationStateRepository = PushNotificationStateRepository(persistenceService: userDefaultsPersistenceService)
+
+            let globalFontUseCase = GlobalFontUseCase(globalFontRepository: globalFontRepository)
+            let pushNotificationStateUseCase = PushNotificationStateUseCase(pushNotificationStateRepository: pushNotificationStateRepository)
+
+            let viewModel = SettingsViewModel(
+                coordinator: self,
+                globalFontUseCase: globalFontUseCase,
+                pushNotificationStateUseCase: pushNotificationStateUseCase
+            )
+
+            let viewController = SettingsViewController(viewModel: viewModel)
             self.presenter.pushViewController(viewController, animated: true)
         }
     }
 
     func dismissSettings() {
-
+        DispatchQueue.main.async {
+            self.presenter.popViewController(animated: true)
+        }
     }
 
     func settingsOptionRequested(with text: String) {
-        
+
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -35,12 +35,6 @@ class SettingsViewCoordinator: SettingsViewCoordinatorProtocol {
         }
     }
 
-    func dismissSettings() {
-        DispatchQueue.main.async {
-            self.presenter.popViewController(animated: true)
-        }
-    }
-
     func settingsOptionRequested(title: String ,text: String) {
         let viewController = SettingsOptionViewController(title: title, content: text)
         self.presenter.topViewController?.navigationController?.pushViewController(viewController, animated: true)

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -36,7 +36,7 @@ class SettingsViewCoordinator: SettingsViewCoordinatorProtocol {
     }
 
     func settingsOptionRequested(title: String ,text: String) {
-        let viewController = SettingsOptionViewController(title: title, content: text)
+        let viewController = SettingsDetailedInfoViewController(title: title, content: text)
         self.presenter.topViewController?.navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -20,4 +20,12 @@ class SettingsViewCoordinator: SettingsViewCoordinatorProtocol {
             self.presenter.pushViewController(viewController, animated: true)
         }
     }
+
+    func dismissSettings() {
+
+    }
+
+    func settingsOptionRequested(with text: String) {
+        
+    }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -1,0 +1,24 @@
+//
+//  SettingsViewCoordinator.swift
+//  Doolda
+//
+//  Created by Dozzing on 2021/11/21.
+//
+
+import UIKit
+
+class SettingsViewCoordinator: SettingsViewCoordinatorProtocol {
+    var presenter: UINavigationController
+
+    init(presenter: UINavigationController) {
+        self.presenter = presenter
+    }
+
+    func start() {
+        DispatchQueue.main.async {
+            let viewController = SettingsViewController()
+            
+            self.presenter.setViewControllers([viewController], animated: true)
+        }
+    }
+}

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -17,8 +17,7 @@ class SettingsViewCoordinator: SettingsViewCoordinatorProtocol {
     func start() {
         DispatchQueue.main.async {
             let viewController = SettingsViewController()
-            
-            self.presenter.setViewControllers([viewController], animated: true)
+            self.presenter.pushViewController(viewController, animated: true)
         }
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -36,7 +36,9 @@ class SettingsViewCoordinator: SettingsViewCoordinatorProtocol {
     }
 
     func settingsOptionRequested(title: String ,text: String) {
-        let viewController = SettingsDetailedInfoViewController(title: title, content: text)
+        let viewController = SettingsDetailedInfoViewController()
+        viewController.titleText = title
+        viewController.contentText = text
         self.presenter.topViewController?.navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -42,9 +42,7 @@ class SettingsViewCoordinator: SettingsViewCoordinatorProtocol {
     }
 
     func settingsOptionRequested(title: String ,text: String) {
-        let label = UILabel()
-        label.text = text
-        let viewController = SettingsOptionViewController(title: title, content: label)
+        let viewController = SettingsOptionViewController(title: title, content: text)
         self.presenter.topViewController?.navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinatorProtocol.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinatorProtocol.swift
@@ -9,5 +9,5 @@ import Foundation
 
 protocol SettingsViewCoordinatorProtocol {
     func dismissSettings()
-    func settingsOptionRequested(with text: String)
+    func settingsOptionRequested(title: String, text: String)
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinatorProtocol.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinatorProtocol.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 protocol SettingsViewCoordinatorProtocol {
-    
+    func dismissSettings()
+    func settingsOptionRequested(with text: String)
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinatorProtocol.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinatorProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  SettingsViewCoordinatorProtocol.swift
+//  Doolda
+//
+//  Created by Dozzing on 2021/11/21.
+//
+
+import Foundation
+
+protocol SettingsViewCoordinatorProtocol {
+    
+}

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinatorProtocol.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinatorProtocol.swift
@@ -8,6 +8,5 @@
 import Foundation
 
 protocol SettingsViewCoordinatorProtocol {
-    func dismissSettings()
     func settingsOptionRequested(title: String, text: String)
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -52,7 +52,10 @@ class SettingsViewModel: SettingsViewModelProtocol {
     }
 
     func openSourceLicenseDidTap() {
-
+        self.coordinator.settingsOptionRequested(
+            title: "Open Source License",
+            text: DooldaInfoType.openSourceLicense.rawValue
+        )
     }
 
     func privacyPolicyDidTap() {

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  SettingViewModel.swift
+//  SettingsViewModel.swift
 //  Doolda
 //
 //  Created by 김민주 on 2021/11/17.
@@ -7,6 +7,6 @@
 
 import Foundation
 
-class SettingViewModel {
+class SettingsViewModel {
     
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -59,11 +59,17 @@ class SettingsViewModel: SettingsViewModelProtocol {
     }
 
     func privacyPolicyDidTap() {
-
+        self.coordinator.settingsOptionRequested(
+            title: "개인 정보 처리 방침",
+            text: DooldaInfoType.openSourceLicense.rawValue
+        )
     }
 
     func contributorDidTap() {
-
+        self.coordinator.settingsOptionRequested(
+            title: "만든 사람들",
+            text: DooldaInfoType.openSourceLicense.rawValue
+        )
     }
 
     func backButtonDidTap() {

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -17,33 +17,48 @@ protocol SettingsViewModelInput {
 }
 
 protocol SettingsViewModelOutput {
-    var selectedFontPublisher: Published<String>.Publisher { get }
+    var selectedFontPublisher: Published<String?>.Publisher { get }
 }
 
 typealias SettingsViewModelProtocol = SettingsViewModelInput & SettingsViewModelOutput
 
 class SettingsViewModel: SettingsViewModelProtocol {
-    var selectedFontPublisher: Published<String>.Publisher { self.$selectedFont }
+    var selectedFontPublisher: Published<String?>.Publisher { self.$selectedFont }
 
-    @Published private var selectedFont: String
+    private let coordinator: SettingsViewCoordinatorProtocol
+    private let globalFontUseCase: GlobalFontUseCaseProtocol
+    private let pushNotificationStateUseCase: PushNotificationStateUseCaseProtocol
+    private var cancellables: Set<AnyCancellable> = []
+    @Published private var selectedFont: String?
+
+    init(
+        coordinator: SettingsViewCoordinatorProtocol,
+        globalFontUseCase: GlobalFontUseCaseProtocol,
+        pushNotificationStateUseCase: PushNotificationStateUseCaseProtocol
+    ) {
+        self.coordinator = coordinator
+        self.globalFontUseCase = globalFontUseCase
+        self.pushNotificationStateUseCase = pushNotificationStateUseCase
+        self.selectedFont = self.globalFontUseCase.getGlobalFont()
+    }
 
     func fontTypeDidChanged(_ fontName: String) {
-        <#code#>
+
     }
 
     func pushNotificationDidToggle() {
-        <#code#>
+
     }
 
     func openSourceLicenseDidTap() {
-        <#code#>
+
     }
 
     func privacyPolicyDidTap() {
-        <#code#>
+
     }
 
     func contributorDidTap() {
-        <#code#>
+
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -61,14 +61,14 @@ class SettingsViewModel: SettingsViewModelProtocol {
     func privacyPolicyDidTap() {
         self.coordinator.settingsOptionRequested(
             title: "개인 정보 처리 방침",
-            text: DooldaInfoType.openSourceLicense.rawValue
+            text: DooldaInfoType.privacyPolicy.rawValue
         )
     }
 
     func contributorDidTap() {
         self.coordinator.settingsOptionRequested(
             title: "만든 사람들",
-            text: DooldaInfoType.openSourceLicense.rawValue
+            text: DooldaInfoType.contributor.rawValue
         )
     }
 

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -14,7 +14,6 @@ protocol SettingsViewModelInput {
     func openSourceLicenseDidTap()
     func privacyPolicyDidTap()
     func contributorDidTap()
-    func backButtonDidTap()
 }
 
 protocol SettingsViewModelOutput {
@@ -72,7 +71,4 @@ class SettingsViewModel: SettingsViewModelProtocol {
         )
     }
 
-    func backButtonDidTap() {
-        self.coordinator.dismissSettings()
-    }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -2,11 +2,48 @@
 //  SettingsViewModel.swift
 //  Doolda
 //
-//  Created by 김민주 on 2021/11/17.
+//  Created by Dozzing on 2021/11/22.
 //
 
+import Combine
 import Foundation
 
-class SettingsViewModel {
-    
+protocol SettingsViewModelInput {
+    func fontTypeDidChanged(_ fontName: String)
+    func pushNotificationDidToggle()
+    func openSourceLicenseDidTap()
+    func privacyPolicyDidTap()
+    func contributorDidTap()
+}
+
+protocol SettingsViewModelOutput {
+    var selectedFontPublisher: Published<String>.Publisher { get }
+}
+
+typealias SettingsViewModelProtocol = SettingsViewModelInput & SettingsViewModelOutput
+
+class SettingsViewModel: SettingsViewModelProtocol {
+    var selectedFontPublisher: Published<String>.Publisher { self.$selectedFont }
+
+    @Published private var selectedFont: String
+
+    func fontTypeDidChanged(_ fontName: String) {
+        <#code#>
+    }
+
+    func pushNotificationDidToggle() {
+        <#code#>
+    }
+
+    func openSourceLicenseDidTap() {
+        <#code#>
+    }
+
+    func privacyPolicyDidTap() {
+        <#code#>
+    }
+
+    func contributorDidTap() {
+        <#code#>
+    }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -14,6 +14,7 @@ protocol SettingsViewModelInput {
     func openSourceLicenseDidTap()
     func privacyPolicyDidTap()
     func contributorDidTap()
+    func backButtonDidTap()
 }
 
 protocol SettingsViewModelOutput {
@@ -60,5 +61,9 @@ class SettingsViewModel: SettingsViewModelProtocol {
 
     func contributorDidTap() {
 
+    }
+
+    func backButtonDidTap() {
+        self.coordinator.dismissSettings()
     }
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -42,13 +42,9 @@ class SettingsViewModel: SettingsViewModelProtocol {
         self.selectedFont = self.globalFontUseCase.getGlobalFont()
     }
 
-    func fontTypeDidChanged(_ fontName: String) {
-
-    }
-
-    func pushNotificationDidToggle() {
-
-    }
+    // FIXME: 아직 구현중인 부분
+    func fontTypeDidChanged(_ fontName: String) { }
+    func pushNotificationDidToggle() {}
 
     func openSourceLicenseDidTap() {
         self.coordinator.settingsOptionRequested(

--- a/Doolda/Doolda/Support/Extensions/UIImage+Extensions.swift
+++ b/Doolda/Doolda/Support/Extensions/UIImage+Extensions.swift
@@ -29,6 +29,4 @@ extension UIImage {
     static let hedgehog = UIImage(named: "hedgehog")
     static let hedgehogWriting = UIImage(named: "hedgehogWriting")
     static let hedgehogFrustrated = UIImage(named: "hedgehogFrustrated")
-    static let left = UIImage(systemName: "chevron.left")
-    static let right = UIImage(systemName: "chevron.right")
 }

--- a/Doolda/Doolda/Support/Extensions/UIImage+Extensions.swift
+++ b/Doolda/Doolda/Support/Extensions/UIImage+Extensions.swift
@@ -28,5 +28,6 @@ extension UIImage {
     static let plus = UIImage(systemName: "plus")
     static let hedgehog = UIImage(named: "hedgehog")
     static let hedgehogWriting = UIImage(named: "hedgehogWriting")
+    static let back = UIImage(systemName: "chevron.backward")
     static let hedgehogFrustrated = UIImage(named: "hedgehogFrustrated")
 }

--- a/Doolda/Doolda/Support/Extensions/UIImage+Extensions.swift
+++ b/Doolda/Doolda/Support/Extensions/UIImage+Extensions.swift
@@ -30,5 +30,5 @@ extension UIImage {
     static let hedgehogWriting = UIImage(named: "hedgehogWriting")
     static let hedgehogFrustrated = UIImage(named: "hedgehogFrustrated")
     static let left = UIImage(systemName: "chevron.left")
-    static let right = UIImage(systemName: "right")
+    static let right = UIImage(systemName: "chevron.right")
 }

--- a/Doolda/Doolda/Support/Extensions/UIImage+Extensions.swift
+++ b/Doolda/Doolda/Support/Extensions/UIImage+Extensions.swift
@@ -28,6 +28,7 @@ extension UIImage {
     static let plus = UIImage(systemName: "plus")
     static let hedgehog = UIImage(named: "hedgehog")
     static let hedgehogWriting = UIImage(named: "hedgehogWriting")
-    static let back = UIImage(systemName: "chevron.backward")
     static let hedgehogFrustrated = UIImage(named: "hedgehogFrustrated")
+    static let left = UIImage(systemName: "chevron.left")
+    static let right = UIImage(systemName: "right")
 }


### PR DESCRIPTION
## 이슈 목록
- [x] #325
- [x] #346
- [x] #281

## 특이사항
**만만하게 봤던 셋팅뷰가 생각보다 커지고 있어서 pr을 분할해 보내고자 합니다 !!!!**

* 폰트 피커와 스위치는 아직 작업중이라 제외하고 올렸습니다.
* 전체적인 레이아웃 위주로 검토해주시면 감사하겠습니다.
*  설정에 관한 데이터는 DooldaInfoType 이라는 엔티티를 정의해 가져오도록 구현했습니다.

## 실행 결과

| SettingsView | 오픈 라이센스 화면 | 다크모드 |
| ---- | ---- | ---- |
| ![Simulator Screen Shot - iPhone 13 - 2021-11-22 at 23 23 37](https://user-images.githubusercontent.com/61934702/142879080-87489c69-c457-4f0a-b450-88bfe0c2c4a9.png) | ![Simulator Screen Shot - iPhone 13 - 2021-11-22 at 23 23 40](https://user-images.githubusercontent.com/61934702/142879117-699b7c51-9c48-4a66-85a1-cffd14646245.png) | ![Simulator Screen Shot - iPhone 13 - 2021-11-22 at 23 23 57](https://user-images.githubusercontent.com/61934702/142879146-8b935077-7ab4-4abf-9ca3-ced994410752.png) |
 
## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

