### PR TITLE
PageCaching 정책 수정

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -229,7 +229,7 @@
 		1D6232F427313D8E00A9AD6B /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		1D6232F6273140CF00A9AD6B /* CopyableLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyableLabel.swift; sourceTree = "<group>"; };
 		1D6232F8273173E300A9AD6B /* UIResponder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extensions.swift"; sourceTree = "<group>"; };
-		1D71B53C274E0C36000B50A8 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = ../Config.xcconfig; sourceTree = "<group>"; };
+		1D71B53C274E0C36000B50A8 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		1D8646A2274D2DB600C4511D /* PushMessageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushMessageEntity.swift; sourceTree = "<group>"; };
 		1D8BE0782740FE5E00201E3E /* PageDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDocument.swift; sourceTree = "<group>"; };
 		1D8BE07A2742A3DB00201E3E /* DiaryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCollectionViewCell.swift; sourceTree = "<group>"; };

--- a/Doolda/Doolda/Data/DataTransferObjects/PageDocument.swift
+++ b/Doolda/Doolda/Data/DataTransferObjects/PageDocument.swift
@@ -10,18 +10,23 @@ import Foundation
 struct PageDocument: Codable {
     var authorId: String? { return self.fields["author"]?["stringValue"] }
     var pairId: String? { return self.fields["pairId"]?["stringValue"] }
-    var timeStamp: String? { return self.fields["createdTime"]?["timestampValue"] }
+    var createdTime: String? { return self.fields["createdTime"]?["timestampValue"] }
+    var updatedTime: String? { return self.fields["updatedTime"]?["timestampValue"] }
     var jsonPath: String? { return self.fields["jsonPath"]?["stringValue"] }
     let fields: [String: [String: String]]
     
-    init(author: String, createdTime: Date, jsonPath: String, pairId: String) {
-        let formattedString = DateFormatter.firestoreFormatter.string(from: createdTime)
+    init(author: String, createdTime: Date, updatedTime: Date, jsonPath: String, pairId: String) {
+        let formattedCreatedTimeString = DateFormatter.firestoreFormatter.string(from: createdTime)
+        let formattedUpdatedTimeString = DateFormatter.firestoreFormatter.string(from: updatedTime)
         self.fields = [
             "author": [
                 "stringValue": author
             ],
             "createdTime": [
-                "timestampValue": formattedString
+                "timestampValue": formattedCreatedTimeString
+            ],
+            "updatedTime": [
+                "timestampValue": formattedUpdatedTimeString
             ],
             "jsonPath": [
                 "stringValue": jsonPath
@@ -35,6 +40,7 @@ struct PageDocument: Codable {
     init?(document: [String: [String: String]]) {
         guard let author = document["author"]?["stringValue"],
               let createdTime = document["createdTime"]?["timestampValue"],
+              let updatedTime = document["updatedTime"]?["timestampValue"],
               let jsonPath = document["jsonPath"]?["stringValue"],
               let pairId = document["pairId"]?["stringValue"] else { return nil }
         self.fields = [
@@ -43,6 +49,9 @@ struct PageDocument: Codable {
             ],
             "createdTime": [
                 "timestampValue": createdTime
+            ],
+            "updatedTime": [
+                "timestampValue": updatedTime
             ],
             "jsonPath": [
                 "stringValue": jsonPath
@@ -58,9 +67,16 @@ struct PageDocument: Codable {
               let pairId = self.pairId,
               let authorDDID = DDID(from: authorId),
               let pairDDID = DDID(from: pairId),
-              let timeStamp = self.timeStamp,
-              let formattedDate = DateFormatter.firestoreFormatter.date(from: timeStamp),
+              let createdTimeString = self.createdTime,
+              let formattedCreatedTime = DateFormatter.firestoreFormatter.date(from: createdTimeString),
+              let updatedTimeString = self.updatedTime,
+              let formattedUpdatedTime = DateFormatter.firestoreFormatter.date(from: updatedTimeString),
               let jsonPath = self.jsonPath else { return nil }
-        return PageEntity(author: User(id: authorDDID, pairId: pairDDID), createdTime: formattedDate, jsonPath: jsonPath)
+        return PageEntity(
+            author: User(id: authorDDID, pairId: pairDDID),
+            createdTime: formattedCreatedTime,
+            updatedTime: formattedUpdatedTime,
+            jsonPath: jsonPath
+        )
     }
 }

--- a/Doolda/Doolda/Data/DataTransferObjects/PageDocument.swift
+++ b/Doolda/Doolda/Data/DataTransferObjects/PageDocument.swift
@@ -61,6 +61,6 @@ struct PageDocument: Codable {
               let timeStamp = self.timeStamp,
               let formattedDate = DateFormatter.firestoreFormatter.date(from: timeStamp),
               let jsonPath = self.jsonPath else { return nil }
-        return PageEntity(author: User(id: authorDDID, pairId: pairDDID), timeStamp: formattedDate, jsonPath: jsonPath)
+        return PageEntity(author: User(id: authorDDID, pairId: pairDDID), createdTime: formattedDate, jsonPath: jsonPath)
     }
 }

--- a/Doolda/Doolda/Data/Interfaces/CoreDataPageEntityPersistenceServiceProtocol.swift
+++ b/Doolda/Doolda/Data/Interfaces/CoreDataPageEntityPersistenceServiceProtocol.swift
@@ -9,6 +9,7 @@ import Combine
 import Foundation
 
 protocol CoreDataPageEntityPersistenceServiceProtocol {
+    func isPageEntityUpToDate(_ pageEntity: PageEntity) -> AnyPublisher<Bool, Error>
     func fetchPageEntities() -> AnyPublisher<[PageEntity], Error>
     func savePageEntity(_ pageEntity: PageEntity) -> AnyPublisher<Void, Error>
     func removeAllPageEntity() -> AnyPublisher<Void, Error>

--- a/Doolda/Doolda/Data/Repositories/PageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PageRepository.swift
@@ -37,7 +37,7 @@ class PageRepository: PageRepositoryProtocol {
     
     func savePage(_ page: PageEntity) -> AnyPublisher<PageEntity, Error> {
         guard let pairId = page.author.pairId?.ddidString else { return Fail(error: PageRepositoryError.userNotPaired).eraseToAnyPublisher() }
-        let request = FirebaseAPIs.createPageDocument(page.author.id.ddidString, page.timeStamp, page.jsonPath, pairId)
+        let request = FirebaseAPIs.createPageDocument(page.author.id.ddidString, page.createdTime, page.jsonPath, pairId)
         let publisher: AnyPublisher<[String: Any], Error> = self.urlSessionNetworkService.request(request)
         
         return publisher
@@ -58,7 +58,7 @@ class PageRepository: PageRepositoryProtocol {
                 } receiveValue: { cachedPages in
                     let latestPageEntity = cachedPages.first
                     
-                    self.fetchPageFromServer(pairId: pair, after: latestPageEntity?.timeStamp)
+                    self.fetchPageFromServer(pairId: pair, after: latestPageEntity?.createdTime)
                         .sink { completion in
                             guard case .failure(let error) = completion else { return }
                             promise(.failure(error))

--- a/Doolda/Doolda/Data/Repositories/RawPageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/RawPageRepository.swift
@@ -61,18 +61,48 @@ class RawPageRepository: RawPageRepositoryProtocol {
         let name = metaData.jsonPath
         let fileName = "\(folder)\(name)"
         
-        if self.fileManagerPersistenceService.isFileExists(at: .cache, fileName: fileName) {
-            return self.fileManagerPersistenceService.fetch(at: .cache, fileName: fileName)
-                       .decode(type: RawPageEntity.self, decoder: JSONDecoder())
-                       .eraseToAnyPublisher()
-        } else {
-            return self.fetchRawPageEntityFromServer(at: folder, with: name)
-                .map { [weak self] rawPageEntity in
-                    self?.saveRawPageEntityToCache(rawPageEntity: rawPageEntity, fileName: fileName)
-                    return rawPageEntity
+        return Future { [weak self] promise in
+            guard let self = self else {
+                return promise(.failure(RawPageRepositoryError.failedToFetchRawPage))
+            }
+            
+            self.coreDataPageEntityPersistenceService.isPageEntityUpToDate(metaData)
+                .sink { completion in
+                    guard case .failure(let error) = completion else { return }
+                    promise(.failure(error))
+                } receiveValue: { [weak self] isUpToDate in
+                    guard let self = self else {
+                        return promise(.failure(RawPageRepositoryError.failedToFetchRawPage))
+                    }
+                    
+                    let fetchPublisher: AnyPublisher<RawPageEntity, Error>
+                    
+                    if self.fileManagerPersistenceService.isFileExists(at: .cache, fileName: fileName),
+                       isUpToDate {
+                        fetchPublisher = self.fileManagerPersistenceService.fetch(at: .cache, fileName: fileName)
+                            .decode(type: RawPageEntity.self, decoder: JSONDecoder())
+                            .eraseToAnyPublisher()
+                    } else {
+                        fetchPublisher = self.fetchRawPageEntityFromServer(at: folder, with: name)
+                            .map { [weak self] rawPageEntity in
+                                self?.saveRawPageEntityToCache(rawPageEntity: rawPageEntity, fileName: fileName)
+                                return rawPageEntity
+                            }
+                            .eraseToAnyPublisher()
+                    }
+                    
+                    fetchPublisher.sink { completion in
+                        guard case .failure(let error) = completion else { return }
+                        promise(.failure(error))
+                    } receiveValue: { [weak self] rawPageEntity in
+                        self?.setIsUpToDateFlag(medaData: metaData)
+                        promise(.success(rawPageEntity))
+                    }
+                    .store(in: &self.cancellables)
                 }
-                .eraseToAnyPublisher()
+                .store(in: &self.cancellables)
         }
+        .eraseToAnyPublisher()
     }
     
     private func fetchRawPageEntityFromServer(at folder: String, with name: String) -> AnyPublisher<RawPageEntity, Error> {
@@ -98,6 +128,15 @@ class RawPageRepository: RawPageRepositoryProtocol {
         }
         
         self.fileManagerPersistenceService.save(data: data, at: .cache, fileName: fileName)
+            .sink { completion in
+                guard case .failure = completion else { return }
+                os_log("RawPageEntity caching failure", type: .fault)
+            } receiveValue: { _ in }
+            .store(in: &self.cancellables)
+    }
+    
+    private func setIsUpToDateFlag(medaData: PageEntity) {
+        self.coreDataPageEntityPersistenceService.savePageEntity(medaData)
             .sink { completion in
                 guard case .failure = completion else { return }
                 os_log("RawPageEntity caching failure", type: .fault)

--- a/Doolda/Doolda/Data/Repositories/RawPageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/RawPageRepository.swift
@@ -54,7 +54,11 @@ class RawPageRepository: RawPageRepositoryProtocol {
         }
     }
     
-    func fetch(at folder: String, with name: String) -> AnyPublisher<RawPageEntity, Error> {
+    func fetch(metaData: PageEntity) -> AnyPublisher<RawPageEntity, Error> {
+        guard let folder = metaData.author.pairId?.ddidString else {
+            return Fail(error: RawPageRepositoryError.failedToFetchRawPage).eraseToAnyPublisher()
+        }
+        let name = metaData.jsonPath
         let fileName = "\(folder)\(name)"
         
         if self.fileManagerPersistenceService.isFileExists(at: .cache, fileName: fileName) {

--- a/Doolda/Doolda/Data/Repositories/RawPageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/RawPageRepository.swift
@@ -22,6 +22,7 @@ enum RawPageRepositoryError: LocalizedError {
 
 class RawPageRepository: RawPageRepositoryProtocol {
     private let networkService: URLSessionNetworkServiceProtocol
+    private let coreDataPageEntityPersistenceService: CoreDataPageEntityPersistenceServiceProtocol
     private let fileManagerPersistenceService: FileManagerPersistenceServiceProtocol
     private let encoder: JSONEncoder
     
@@ -29,10 +30,12 @@ class RawPageRepository: RawPageRepositoryProtocol {
     
     init(
         networkService: URLSessionNetworkServiceProtocol,
+        coreDataPageEntityPersistenceService: CoreDataPageEntityPersistenceServiceProtocol,
         fileManagerPersistenceService: FileManagerPersistenceServiceProtocol,
         encoder: JSONEncoder = JSONEncoder()
     ) {
         self.networkService = networkService
+        self.coreDataPageEntityPersistenceService = coreDataPageEntityPersistenceService
         self.fileManagerPersistenceService = fileManagerPersistenceService
         self.encoder = encoder
     }

--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -216,7 +216,7 @@ class DiaryViewController: UIViewController {
                 
                 guard let viewModel = self?.viewModel else { return nil }
                 cell.displayRawPage(with: viewModel.pageDidDisplay(jsonPath: pageEntity.jsonPath))
-                cell.timestamp = pageEntity.timeStamp
+                cell.timestamp = pageEntity.createdTime
                 return cell
         })
         

--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -215,7 +215,7 @@ class DiaryViewController: UIViewController {
                 ) as? DiaryCollectionViewCell else { return nil }
                 
                 guard let viewModel = self?.viewModel else { return nil }
-                cell.displayRawPage(with: viewModel.pageDidDisplay(jsonPath: pageEntity.jsonPath))
+                cell.displayRawPage(with: viewModel.pageDidDisplay(metaData: pageEntity))
                 cell.timestamp = pageEntity.createdTime
                 return cell
         })

--- a/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
@@ -31,6 +31,7 @@ class DiaryViewCoordinator: DiaryViewCoordinatorProtocol {
         
         let rawPageRepository = RawPageRepository(
             networkService: urlSessionNetworkService,
+            coreDataPageEntityPersistenceService: coreDataPageEntityPersistenceService,
             fileManagerPersistenceService: fileManagerPersistenceService
         )
         

--- a/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
@@ -18,7 +18,7 @@ protocol DiaryViewModelInput {
     func filterDidApply(author: DiaryAuthorFilter, orderBy: DiaryOrderFilter)
     func filterOptionDidChange(author: DiaryAuthorFilter, orderBy: DiaryOrderFilter)
     func filterBottomSheetDidDismiss()
-    func pageDidDisplay(jsonPath: String) -> AnyPublisher<RawPageEntity, Error>
+    func pageDidDisplay(metaData: PageEntity) -> AnyPublisher<RawPageEntity, Error>
     func getDate(of index: Int) -> Date?
 }
 
@@ -143,9 +143,8 @@ class DiaryViewModel: DiaryViewModelProtocol {
         self.fetchPages()
     }
     
-    func pageDidDisplay(jsonPath: String) -> AnyPublisher<RawPageEntity, Error> {
-        guard let pairId = self.user.pairId else { return Fail(error: DiaryViewModelError.userNotPaired).eraseToAnyPublisher() }
-        return self.getRawPageUseCase.getRawPageEntity(for: pairId, jsonPath: jsonPath)
+    func pageDidDisplay(metaData: PageEntity) -> AnyPublisher<RawPageEntity, Error> {
+        return self.getRawPageUseCase.getRawPageEntity(metaData: metaData)
     }
 
     func displayModeToggleButtonDidTap() {

--- a/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
@@ -185,7 +185,7 @@ class DiaryViewModel: DiaryViewModelProtocol {
     }
     
     func getDate(of index: Int) -> Date? {
-        return filteredPageEntities[exist: index]?.timeStamp
+        return filteredPageEntities[exist: index]?.createdTime
     }
     
     private func fetchPages() {
@@ -207,7 +207,7 @@ class DiaryViewModel: DiaryViewModelProtocol {
     
     private func filterPageEntities(entities: [PageEntity], authorFilter: DiaryAuthorFilter, orderFilter: DiaryOrderFilter) {
         let filtered = entities.filter { authorFilter == .both ? true : (authorFilter == .user ? ($0.author.id == self.user.id) : ($0.author.id != self.user.id)) }
-        let ordered = filtered.sorted { orderFilter == .descending ? ($0.timeStamp >= $1.timeStamp) : ($0.timeStamp <= $1.timeStamp) }
+        let ordered = filtered.sorted { orderFilter == .descending ? ($0.createdTime >= $1.createdTime) : ($0.createdTime <= $1.createdTime) }
         self.filteredPageEntities = ordered
     }
 }

--- a/Doolda/Doolda/Domain/Entities/PageEntity.swift
+++ b/Doolda/Doolda/Domain/Entities/PageEntity.swift
@@ -9,12 +9,14 @@ import Foundation
 
 struct PageEntity: Hashable {
     let author: User
-    let timeStamp: Date
+    let createdTime: Date
+    let updatedTime: Date
     let jsonPath: String
     
     func hash(into hasher: inout Hasher) {
         hasher.combine(author)
-        hasher.combine(timeStamp)
+        hasher.combine(createdTime)
+        hasher.combine(updatedTime)
         hasher.combine(jsonPath)
     }
 }

--- a/Doolda/Doolda/Domain/Interfaces/RawPageRepositoryProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/RawPageRepositoryProtocol.swift
@@ -10,5 +10,5 @@ import Foundation
 
 protocol RawPageRepositoryProtocol {
     func save(rawPage: RawPageEntity, at folder: String, with name: String) -> AnyPublisher<RawPageEntity, Error>
-    func fetch(at folder: String, with name: String) -> AnyPublisher<RawPageEntity, Error>
+    func fetch(metaData: PageEntity) -> AnyPublisher<RawPageEntity, Error>
 }

--- a/Doolda/Doolda/Domain/UseCases/EditPageUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/EditPageUseCase.swift
@@ -147,7 +147,7 @@ class EditPageUseCase: EditPageUseCaseProtocol {
         
         let currentTime = Date()
         let path = DateFormatter.jsonPathFormatter.string(from: currentTime)
-        let metaData = PageEntity(author: author, timeStamp: currentTime, jsonPath: path)
+        let metaData = PageEntity(author: author, createdTime: currentTime, jsonPath: path)
         
         let imageUploadPublishers = page.components
             .compactMap { $0 as? PhotoComponentEntity }

--- a/Doolda/Doolda/Domain/UseCases/EditPageUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/EditPageUseCase.swift
@@ -147,7 +147,9 @@ class EditPageUseCase: EditPageUseCaseProtocol {
         
         let currentTime = Date()
         let path = DateFormatter.jsonPathFormatter.string(from: currentTime)
-        let metaData = PageEntity(author: author, createdTime: currentTime, jsonPath: path)
+        // FIXME: Edit 동작이 구현되면 updateTime수정할 것!
+        // FIXME: 첫 생성은 currenTime과 같은것으로 대입!
+        let metaData = PageEntity(author: author, createdTime: currentTime, updatedTime: currentTime, jsonPath: path)
         
         let imageUploadPublishers = page.components
             .compactMap { $0 as? PhotoComponentEntity }

--- a/Doolda/Doolda/Domain/UseCases/GetRawPageUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/GetRawPageUseCase.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 
 protocol GetRawPageUseCaseProtocol {
-    func getRawPageEntity(for pairId: DDID, jsonPath: String) -> AnyPublisher<RawPageEntity, Error>
+    func getRawPageEntity(metaData: PageEntity) -> AnyPublisher<RawPageEntity, Error>
 }
 
 class GetRawPageUseCase: GetRawPageUseCaseProtocol {
@@ -19,7 +19,7 @@ class GetRawPageUseCase: GetRawPageUseCaseProtocol {
         self.rawPageRepository = rawPageRepository
     }
     
-    func getRawPageEntity(for pairId: DDID, jsonPath: String) -> AnyPublisher<RawPageEntity, Error> {
-        return self.rawPageRepository.fetch(at: pairId.ddidString, with: jsonPath)
+    func getRawPageEntity(metaData: PageEntity) -> AnyPublisher<RawPageEntity, Error> {
+        return self.rawPageRepository.fetch(metaData: metaData)
     }
 }

--- a/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
@@ -37,6 +37,7 @@ class EditPageViewCoordinator: EditPageViewCoordinatorProtocol {
             )
             let rawPageRepository = RawPageRepository(
                 networkService: urlSessionNetworkService,
+                coreDataPageEntityPersistenceService: coreDataPageEntityPersistenceService,
                 fileManagerPersistenceService: fileManagerPersistenceService
             )
             let fcmTokenRepository = FCMTokenRepository(urlSessionNetworkService: urlSessionNetworkService)

--- a/Doolda/Doolda/Resources/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/Doolda/Doolda/Resources/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19206" systemVersion="20G165" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="CoreDataPageEntity" representedClassName="CoreDataPageEntity" syncable="YES">
+        <attribute name="createdTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="jsonPath" optional="YES" attributeType="String"/>
         <attribute name="pairId" optional="YES" attributeType="String"/>
-        <attribute name="timeStamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="updatedTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
     <elements>
-        <element name="CoreDataPageEntity" positionX="-54" positionY="-9" width="128" height="89"/>
+        <element name="CoreDataPageEntity" positionX="-54" positionY="-9" width="128" height="104"/>
     </elements>
 </model>

--- a/Doolda/Doolda/Resources/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/Doolda/Doolda/Resources/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -3,11 +3,12 @@
     <entity name="CoreDataPageEntity" representedClassName="CoreDataPageEntity" syncable="YES">
         <attribute name="createdTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="isUpToDate" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="jsonPath" optional="YES" attributeType="String"/>
         <attribute name="pairId" optional="YES" attributeType="String"/>
         <attribute name="updatedTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
     </entity>
     <elements>
-        <element name="CoreDataPageEntity" positionX="-54" positionY="-9" width="128" height="104"/>
+        <element name="CoreDataPageEntity" positionX="-54" positionY="-9" width="128" height="119"/>
     </elements>
 </model>

--- a/Doolda/Doolda/Service/CoreData/CoreDataPageEntity+CoreDataProperties.swift
+++ b/Doolda/Doolda/Service/CoreData/CoreDataPageEntity+CoreDataProperties.swift
@@ -25,14 +25,14 @@ extension CoreDataPageEntity {
               let timeStamp = timeStamp,
               let jsonPath = jsonPath else { return nil }
         
-        return PageEntity(author: User(id: id, pairId: pairId), timeStamp: timeStamp, jsonPath: jsonPath)
+        return PageEntity(author: User(id: id, pairId: pairId), createdTime: timeStamp, jsonPath: jsonPath)
     }
     
     func update(_ pageEntity: PageEntity) {
         self.id = pageEntity.author.id.ddidString
         self.pairId = pageEntity.author.pairId?.ddidString
         self.jsonPath = pageEntity.jsonPath
-        self.timeStamp = pageEntity.timeStamp
+        self.timeStamp = pageEntity.createdTime
     }
 }
 

--- a/Doolda/Doolda/Service/CoreData/CoreDataPageEntity+CoreDataProperties.swift
+++ b/Doolda/Doolda/Service/CoreData/CoreDataPageEntity+CoreDataProperties.swift
@@ -17,22 +17,30 @@ extension CoreDataPageEntity {
     @NSManaged public var id: String?
     @NSManaged public var pairId: String?
     @NSManaged public var jsonPath: String?
-    @NSManaged public var timeStamp: Date?
+    @NSManaged public var createdTime: Date?
+    @NSManaged public var updatedTime: Date?
 
     func toPageEntity() -> PageEntity? {
         guard let id = DDID(from: id ?? ""),
               let pairId = DDID(from: pairId ?? ""),
-              let timeStamp = timeStamp,
+              let createdTime = createdTime,
+              let updatedTime = updatedTime,
               let jsonPath = jsonPath else { return nil }
         
-        return PageEntity(author: User(id: id, pairId: pairId), createdTime: timeStamp, jsonPath: jsonPath)
+        return PageEntity(
+            author: User(id: id, pairId: pairId),
+            createdTime: createdTime,
+            updatedTime: updatedTime,
+            jsonPath: jsonPath
+        )
     }
     
     func update(_ pageEntity: PageEntity) {
         self.id = pageEntity.author.id.ddidString
         self.pairId = pageEntity.author.pairId?.ddidString
         self.jsonPath = pageEntity.jsonPath
-        self.timeStamp = pageEntity.createdTime
+        self.createdTime = pageEntity.createdTime
+        self.updatedTime = pageEntity.updatedTime
     }
 }
 

--- a/Doolda/Doolda/Service/CoreData/CoreDataPageEntity+CoreDataProperties.swift
+++ b/Doolda/Doolda/Service/CoreData/CoreDataPageEntity+CoreDataProperties.swift
@@ -19,6 +19,7 @@ extension CoreDataPageEntity {
     @NSManaged public var jsonPath: String?
     @NSManaged public var createdTime: Date?
     @NSManaged public var updatedTime: Date?
+    @NSManaged public var isUpToDate: Bool
 
     func toPageEntity() -> PageEntity? {
         guard let id = DDID(from: id ?? ""),
@@ -40,6 +41,7 @@ extension CoreDataPageEntity {
         self.pairId = pageEntity.author.pairId?.ddidString
         self.jsonPath = pageEntity.jsonPath
         self.createdTime = pageEntity.createdTime
+        self.isUpToDate = self.updatedTime == pageEntity.updatedTime
         self.updatedTime = pageEntity.updatedTime
     }
 }

--- a/Doolda/Doolda/Support/Constants/API.swift
+++ b/Doolda/Doolda/Support/Constants/API.swift
@@ -17,7 +17,7 @@ enum FirebaseAPIs: URLRequestBuilder {
     case patchPairDocument(String, String)
     
     case getPageDocuments(String, Date?)
-    case createPageDocument(String, Date, String, String)
+    case createPageDocument(String, Date, Date, String, String)
     
     case getFCMTokenDocument(String)
     case patchFCMTokenDocument(String, String)
@@ -70,7 +70,7 @@ extension FirebaseAPIs {
             return nil
         case .createUserDocument(let id), .createPairDocument(let id, _):
             return ["documentId": id]
-        case .createPageDocument(_, _, let jsonPath, let pairId):
+        case .createPageDocument(_, _, _, let jsonPath, let pairId):
             return ["documentId": pairId + jsonPath]
         case .patchUserDocument, .patchPairDocument:
             return ["currentDocument.exists": "true"]
@@ -168,8 +168,14 @@ extension FirebaseAPIs {
             return [
                 "fields": pairDocument.fields
             ]
-        case .createPageDocument(let authorId, let createdTime, let jsonPath, let pairId):
-            let pageDocument = PageDocument(author: authorId, createdTime: createdTime, jsonPath: jsonPath, pairId: pairId)
+        case .createPageDocument(let authorId, let createdTime, let updatedTime, let jsonPath, let pairId):
+            let pageDocument = PageDocument(
+                author: authorId,
+                createdTime: createdTime,
+                updatedTime: updatedTime,
+                jsonPath: jsonPath,
+                pairId: pairId
+            )
             return [
                 "fields": pageDocument.fields
             ]


### PR DESCRIPTION
## 이슈 목록
- [ ] #371 

## 특이사항
* PageEntity의 `timeStamp`를 `createdTime`, `updatedTime`으로 분리했습니다. PageEntity에 관련있는 부분이 수정되어 넓게 변경이 있습니다.
* RawPageEntity를 fetch할때 folder, name이 아니라 RawPageEntity의 MetaData인 PageEntity를 파라미터로 전달하도록 수정했습니다.
* RawPageEntity의 변경을 확인하려면 변경을 비교할 정보가 있어야(로컬에 캐싱된 json 파일이 있는지는 알아야하니까?) 하기 때문에 PageEntity를 CoreData에 유지하기로 결정했습니다. 
* PageEntity를 CoreData에 저장하긴 하지만 11. 23(화) 저녁에 상의 했던것 처럼 PageEntity를 위한 캐시 정책은 제거했습니다.


## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

