### PR TITLE
Firebase 메시지 관련 UseCase, Repository구현 및 실제 동작과 통합

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		1D999466274CAB8900C72273 /* FCMTokenRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D999465274CAB8900C72273 /* FCMTokenRepository.swift */; };
 		1D999468274CAC4700C72273 /* FCMTokenDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D999467274CAC4700C72273 /* FCMTokenDocument.swift */; };
 		1D99946A274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D999469274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift */; };
+		1D99946C274CEF2900C72273 /* FirebaseMessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D99946B274CEF2900C72273 /* FirebaseMessageRepository.swift */; };
 		1D9DC09D2749F2BE0060587B /* FilterOptionBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9DC09C2749F2BE0060587B /* FilterOptionBottomSheetViewController.swift */; };
 		1D9DC09F274A0E290060587B /* FilterOptionBottomSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9DC09E274A0E290060587B /* FilterOptionBottomSheetViewModel.swift */; };
 		1D9DC0A1274A47D50060587B /* DooldaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9DC0A0274A47D50060587B /* DooldaButton.swift */; };
@@ -233,6 +234,7 @@
 		1D999465274CAB8900C72273 /* FCMTokenRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenRepository.swift; sourceTree = "<group>"; };
 		1D999467274CAC4700C72273 /* FCMTokenDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenDocument.swift; sourceTree = "<group>"; };
 		1D999469274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseMessageRepositoryProtocol.swift; sourceTree = "<group>"; };
+		1D99946B274CEF2900C72273 /* FirebaseMessageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseMessageRepository.swift; sourceTree = "<group>"; };
 		1D9DC09C2749F2BE0060587B /* FilterOptionBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterOptionBottomSheetViewController.swift; sourceTree = "<group>"; };
 		1D9DC09E274A0E290060587B /* FilterOptionBottomSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterOptionBottomSheetViewModel.swift; sourceTree = "<group>"; };
 		1D9DC0A0274A47D50060587B /* DooldaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DooldaButton.swift; sourceTree = "<group>"; };
@@ -639,6 +641,7 @@
 				FCD24D792743AACE000203F7 /* PushNotificationStateRepository.swift */,
 				FCD24D7227439268000203F7 /* GlobalFontRepository.swift */,
 				1D999465274CAB8900C72273 /* FCMTokenRepository.swift */,
+				1D99946B274CEF2900C72273 /* FirebaseMessageRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -1163,6 +1166,7 @@
 				664894182730F1B1009F03E2 /* PairingViewModel.swift in Sources */,
 				66CD644E273A490800E55C03 /* BottomSheetViewController.swift in Sources */,
 				66FE936F27356E160036CED2 /* User.swift in Sources */,
+				1D99946C274CEF2900C72273 /* FirebaseMessageRepository.swift in Sources */,
 				FCD24D7327439268000203F7 /* GlobalFontRepository.swift in Sources */,
 				FC5FB7DC2733A4AA008AC3D2 /* UserDefaults+Extensions.swift in Sources */,
 				FC5FB793273260C3008AC3D2 /* UserRepository.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		1D999468274CAC4700C72273 /* FCMTokenDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D999467274CAC4700C72273 /* FCMTokenDocument.swift */; };
 		1D99946A274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D999469274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift */; };
 		1D99946C274CEF2900C72273 /* FirebaseMessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D99946B274CEF2900C72273 /* FirebaseMessageRepository.swift */; };
+		1D99946E274CEFC500C72273 /* FirebaseMessageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D99946D274CEFC500C72273 /* FirebaseMessageUseCase.swift */; };
 		1D9DC09D2749F2BE0060587B /* FilterOptionBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9DC09C2749F2BE0060587B /* FilterOptionBottomSheetViewController.swift */; };
 		1D9DC09F274A0E290060587B /* FilterOptionBottomSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9DC09E274A0E290060587B /* FilterOptionBottomSheetViewModel.swift */; };
 		1D9DC0A1274A47D50060587B /* DooldaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9DC0A0274A47D50060587B /* DooldaButton.swift */; };
@@ -235,6 +236,7 @@
 		1D999467274CAC4700C72273 /* FCMTokenDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenDocument.swift; sourceTree = "<group>"; };
 		1D999469274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseMessageRepositoryProtocol.swift; sourceTree = "<group>"; };
 		1D99946B274CEF2900C72273 /* FirebaseMessageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseMessageRepository.swift; sourceTree = "<group>"; };
+		1D99946D274CEFC500C72273 /* FirebaseMessageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseMessageUseCase.swift; sourceTree = "<group>"; };
 		1D9DC09C2749F2BE0060587B /* FilterOptionBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterOptionBottomSheetViewController.swift; sourceTree = "<group>"; };
 		1D9DC09E274A0E290060587B /* FilterOptionBottomSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterOptionBottomSheetViewModel.swift; sourceTree = "<group>"; };
 		1D9DC0A0274A47D50060587B /* DooldaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DooldaButton.swift; sourceTree = "<group>"; };
@@ -709,6 +711,7 @@
 				FCD24D7727439717000203F7 /* GlobalFontUseCase.swift */,
 				66C482DA2746135500823151 /* GetRawPageUseCase.swift */,
 				1D999461274CA94600C72273 /* FCMTokenUseCase.swift */,
+				1D99946D274CEFC500C72273 /* FirebaseMessageUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -1182,6 +1185,7 @@
 				66ECCD3A273E5342003990EE /* CarouselView.swift in Sources */,
 				66CAFF242740F63A00A48DCF /* BackgroundTypePickerViewController.swift in Sources */,
 				FC9F105B2730F1B20060FEB7 /* UserRepositoryProtocol.swift in Sources */,
+				1D99946E274CEFC500C72273 /* FirebaseMessageUseCase.swift in Sources */,
 				1D58277D2732883E00FD0EA5 /* PairingViewCoordinatorProtocol.swift in Sources */,
 				665303A02743B7FE00E3075C /* CoreDataPageEntity+CoreDataClass.swift in Sources */,
 				31012596273842B300E43160 /* StickerComponentEntity.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		1D999464274CAAAC00C72273 /* FCMTokenRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D999463274CAAAC00C72273 /* FCMTokenRepositoryProtocol.swift */; };
 		1D999466274CAB8900C72273 /* FCMTokenRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D999465274CAB8900C72273 /* FCMTokenRepository.swift */; };
 		1D999468274CAC4700C72273 /* FCMTokenDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D999467274CAC4700C72273 /* FCMTokenDocument.swift */; };
+		1D99946A274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D999469274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift */; };
 		1D9DC09D2749F2BE0060587B /* FilterOptionBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9DC09C2749F2BE0060587B /* FilterOptionBottomSheetViewController.swift */; };
 		1D9DC09F274A0E290060587B /* FilterOptionBottomSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9DC09E274A0E290060587B /* FilterOptionBottomSheetViewModel.swift */; };
 		1D9DC0A1274A47D50060587B /* DooldaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9DC0A0274A47D50060587B /* DooldaButton.swift */; };
@@ -231,6 +232,7 @@
 		1D999463274CAAAC00C72273 /* FCMTokenRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenRepositoryProtocol.swift; sourceTree = "<group>"; };
 		1D999465274CAB8900C72273 /* FCMTokenRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenRepository.swift; sourceTree = "<group>"; };
 		1D999467274CAC4700C72273 /* FCMTokenDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenDocument.swift; sourceTree = "<group>"; };
+		1D999469274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseMessageRepositoryProtocol.swift; sourceTree = "<group>"; };
 		1D9DC09C2749F2BE0060587B /* FilterOptionBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterOptionBottomSheetViewController.swift; sourceTree = "<group>"; };
 		1D9DC09E274A0E290060587B /* FilterOptionBottomSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterOptionBottomSheetViewModel.swift; sourceTree = "<group>"; };
 		1D9DC0A0274A47D50060587B /* DooldaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DooldaButton.swift; sourceTree = "<group>"; };
@@ -739,6 +741,7 @@
 				FCD24D7B2743AAE2000203F7 /* PushNotificationStateRepositoryProtocol.swift */,
 				FCD24D74274392AB000203F7 /* GlobalFontRepositoryProtocol.swift */,
 				1D999463274CAAAC00C72273 /* FCMTokenRepositoryProtocol.swift */,
+				1D999469274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift */,
 			);
 			path = Interfaces;
 			sourceTree = "<group>";
@@ -1082,6 +1085,7 @@
 				66CD645A273BE5A000E55C03 /* PhotoPickerCollectionViewCell.swift in Sources */,
 				1D3925B5273B9172003A0B70 /* DateFormatter+Extensions.swift in Sources */,
 				FCC803FA27451A8000FFE4DC /* TextEditViewController.swift in Sources */,
+				1D99946A274CE5F700C72273 /* FirebaseMessageRepositoryProtocol.swift in Sources */,
 				FC822FAA2736088100C918A0 /* URLSessionNetworkService.swift in Sources */,
 				FC822FAC27360F8600C918A0 /* URLRequsetBuilder.swift in Sources */,
 				310125922738325800E43160 /* UIAlertController+Extensions.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		1D04F41C273957E600CFCC3A /* BackgroundType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D04F41B273957E600CFCC3A /* BackgroundType.swift */; };
 		1D097E97273CFA5900A4810B /* RawPageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D097E96273CFA5900A4810B /* RawPageRepository.swift */; };
 		1D0C8BC42732AF780091ACC0 /* GetUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0C8BC32732AF780091ACC0 /* GetUserUseCase.swift */; };
-		1D2E22C6274C87F600A902B2 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 1D2E22C5274C87F600A902B2 /* FirebaseMessaging */; };
 		1D3629FE2733C79300CFC069 /* RegisterUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3629FD2733C79300CFC069 /* RegisterUserUseCase.swift */; };
 		1D3925B5273B9172003A0B70 /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3925B4273B9172003A0B70 /* DateFormatter+Extensions.swift */; };
 		1D3925BD273BB4BE003A0B70 /* EditPageUseCaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3925BC273BB4BE003A0B70 /* EditPageUseCaseTest.swift */; };
@@ -41,6 +40,7 @@
 		1D6232F7273140CF00A9AD6B /* CopyableLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F6273140CF00A9AD6B /* CopyableLabel.swift */; };
 		1D6232F9273173E300A9AD6B /* UIResponder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F8273173E300A9AD6B /* UIResponder+Extensions.swift */; };
 		1D8646A3274D2DB600C4511D /* PushMessageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8646A2274D2DB600C4511D /* PushMessageEntity.swift */; };
+		1D8646A7274D61BE00C4511D /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 1D8646A6274D61BE00C4511D /* FirebaseMessaging */; };
 		1D8BE0792740FE5E00201E3E /* PageDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BE0782740FE5E00201E3E /* PageDocument.swift */; };
 		1D8BE07B2742A3DB00201E3E /* DiaryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BE07A2742A3DB00201E3E /* DiaryCollectionViewCell.swift */; };
 		1D8BE07D2743437600201E3E /* DiaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BE07C2743437600201E3E /* DiaryViewModel.swift */; };
@@ -384,7 +384,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1D2E22C6274C87F600A902B2 /* FirebaseMessaging in Frameworks */,
+				1D8646A7274D61BE00C4511D /* FirebaseMessaging in Frameworks */,
 				664893F027300DB9009F03E2 /* Kingfisher in Frameworks */,
 				664893ED27300D7D009F03E2 /* SnapKit in Frameworks */,
 			);
@@ -399,6 +399,13 @@
 				1D3925BC273BB4BE003A0B70 /* EditPageUseCaseTest.swift */,
 			);
 			path = EditPageUseCaseTest;
+			sourceTree = "<group>";
+		};
+		1D8646A4274D60AA00C4511D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		1D9DC09B2749F2AA0060587B /* FilterOptionScene */ = {
@@ -566,7 +573,7 @@
 				664893BF273007ED009F03E2 /* Doolda */,
 				1D9FAD4A2747B82B00198B93 /* Tests */,
 				664893BE273007ED009F03E2 /* Products */,
-				FC51FA6E274D301C0069D39C /* Recovered References */,
+				1D8646A4274D60AA00C4511D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -899,7 +906,7 @@
 			packageProductDependencies = (
 				664893EC27300D7D009F03E2 /* SnapKit */,
 				664893EF27300DB9009F03E2 /* Kingfisher */,
-				1D2E22C5274C87F600A902B2 /* FirebaseMessaging */,
+				1D8646A6274D61BE00C4511D /* FirebaseMessaging */,
 			);
 			productName = Doolda;
 			productReference = 664893BD273007ED009F03E2 /* Doolda.app */;
@@ -940,7 +947,7 @@
 				664893EB27300D7D009F03E2 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				664893EE27300DB9009F03E2 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				664893F127300E28009F03E2 /* XCRemoteSwiftPackageReference "SwiftLint" */,
-				1D2E22C4274C87F600A902B2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				1D8646A5274D61BE00C4511D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 664893BE273007ED009F03E2 /* Products */;
 			projectDirPath = "";
@@ -1532,12 +1539,13 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		1D2E22C4274C87F600A902B2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+		1D8646A5274D61BE00C4511D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 8.0.0;
+				kind = versionRange;
+				maximumVersion = 8.0.0;
+				minimumVersion = 7.0.0;
 			};
 		};
 		664893EB27300D7D009F03E2 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
@@ -1567,9 +1575,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		1D2E22C5274C87F600A902B2 /* FirebaseMessaging */ = {
+		1D8646A6274D61BE00C4511D /* FirebaseMessaging */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1D2E22C4274C87F600A902B2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = 1D8646A5274D61BE00C4511D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
 		};
 		664893EC27300D7D009F03E2 /* SnapKit */ = {

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		1D6232F527313D8E00A9AD6B /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F427313D8E00A9AD6B /* UIView+Extensions.swift */; };
 		1D6232F7273140CF00A9AD6B /* CopyableLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F6273140CF00A9AD6B /* CopyableLabel.swift */; };
 		1D6232F9273173E300A9AD6B /* UIResponder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F8273173E300A9AD6B /* UIResponder+Extensions.swift */; };
+		1D8646A3274D2DB600C4511D /* PushMessageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8646A2274D2DB600C4511D /* PushMessageEntity.swift */; };
 		1D8BE0792740FE5E00201E3E /* PageDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BE0782740FE5E00201E3E /* PageDocument.swift */; };
 		1D8BE07B2742A3DB00201E3E /* DiaryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BE07A2742A3DB00201E3E /* DiaryCollectionViewCell.swift */; };
 		1D8BE07D2743437600201E3E /* DiaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BE07C2743437600201E3E /* DiaryViewModel.swift */; };
@@ -223,6 +224,7 @@
 		1D6232F427313D8E00A9AD6B /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		1D6232F6273140CF00A9AD6B /* CopyableLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyableLabel.swift; sourceTree = "<group>"; };
 		1D6232F8273173E300A9AD6B /* UIResponder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extensions.swift"; sourceTree = "<group>"; };
+		1D8646A2274D2DB600C4511D /* PushMessageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushMessageEntity.swift; sourceTree = "<group>"; };
 		1D8BE0782740FE5E00201E3E /* PageDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDocument.swift; sourceTree = "<group>"; };
 		1D8BE07A2742A3DB00201E3E /* DiaryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCollectionViewCell.swift; sourceTree = "<group>"; };
 		1D8BE07C2743437600201E3E /* DiaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryViewModel.swift; sourceTree = "<group>"; };
@@ -732,6 +734,7 @@
 				31012597273842DA00E43160 /* TextComponentEntity.swift */,
 				3101259B2738430200E43160 /* StickerPackEntity.swift */,
 				317FB616274BAAEB005DF3A3 /* DooldaInfoType.swift */,
+				1D8646A2274D2DB600C4511D /* PushMessageEntity.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -1124,6 +1127,7 @@
 				665303A82744C6F500E3075C /* CoreDataPageEntityPersistenceService.swift in Sources */,
 				1D9DC0A5274B8A890060587B /* Collection+Extensions.swift in Sources */,
 				664893FA27302905009F03E2 /* SplashViewCoordinator.swift in Sources */,
+				1D8646A3274D2DB600C4511D /* PushMessageEntity.swift in Sources */,
 				FCE9D3DE2738CFB50001F155 /* PairRepository.swift in Sources */,
 				317FB619274BBC9D005DF3A3 /* SettingsTableViewHeader.swift in Sources */,
 				317FB60B274A3851005DF3A3 /* StickerPickerCollectionViewFooter.swift in Sources */,

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -39,8 +39,9 @@
 		1D6232F527313D8E00A9AD6B /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F427313D8E00A9AD6B /* UIView+Extensions.swift */; };
 		1D6232F7273140CF00A9AD6B /* CopyableLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F6273140CF00A9AD6B /* CopyableLabel.swift */; };
 		1D6232F9273173E300A9AD6B /* UIResponder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6232F8273173E300A9AD6B /* UIResponder+Extensions.swift */; };
+		1D71B53D274E0C36000B50A8 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1D71B53C274E0C36000B50A8 /* Config.xcconfig */; };
+		1D71B540274E0CD5000B50A8 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 1D71B53F274E0CD5000B50A8 /* FirebaseMessaging */; };
 		1D8646A3274D2DB600C4511D /* PushMessageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8646A2274D2DB600C4511D /* PushMessageEntity.swift */; };
-		1D8646A7274D61BE00C4511D /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 1D8646A6274D61BE00C4511D /* FirebaseMessaging */; };
 		1D8BE0792740FE5E00201E3E /* PageDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BE0782740FE5E00201E3E /* PageDocument.swift */; };
 		1D8BE07B2742A3DB00201E3E /* DiaryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BE07A2742A3DB00201E3E /* DiaryCollectionViewCell.swift */; };
 		1D8BE07D2743437600201E3E /* DiaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BE07C2743437600201E3E /* DiaryViewModel.swift */; };
@@ -159,9 +160,7 @@
 		FC28CB32274609F300BA47BB /* TextUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC28CB31274609F300BA47BB /* TextUseCase.swift */; };
 		FC51FA67274BB9D60069D39C /* FontColorPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC51FA66274BB9D60069D39C /* FontColorPickerView.swift */; };
 		FC51FA69274BBB3C0069D39C /* FontColorCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC51FA68274BBB3C0069D39C /* FontColorCollectionViewCell.swift */; };
-		FC51FA6B274C7D910069D39C /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FC51FA6A274C7D910069D39C /* Config.xcconfig */; };
 		FC51FA6D274C89330069D39C /* FontSizeControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC51FA6C274C89330069D39C /* FontSizeControlView.swift */; };
-		FC51FA70274D4C4C0069D39C /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FC51FA6F274D4C4C0069D39C /* Config.xcconfig */; };
 		FC5FB79027325C4D008AC3D2 /* UserDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB78F27325C4D008AC3D2 /* UserDocument.swift */; };
 		FC5FB793273260C3008AC3D2 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB792273260C3008AC3D2 /* UserRepository.swift */; };
 		FC5FB7952732627C008AC3D2 /* PairDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB7942732627C008AC3D2 /* PairDocument.swift */; };
@@ -224,6 +223,7 @@
 		1D6232F427313D8E00A9AD6B /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
 		1D6232F6273140CF00A9AD6B /* CopyableLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyableLabel.swift; sourceTree = "<group>"; };
 		1D6232F8273173E300A9AD6B /* UIResponder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extensions.swift"; sourceTree = "<group>"; };
+		1D71B53C274E0C36000B50A8 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = ../Config.xcconfig; sourceTree = "<group>"; };
 		1D8646A2274D2DB600C4511D /* PushMessageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushMessageEntity.swift; sourceTree = "<group>"; };
 		1D8BE0782740FE5E00201E3E /* PageDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDocument.swift; sourceTree = "<group>"; };
 		1D8BE07A2742A3DB00201E3E /* DiaryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -329,9 +329,7 @@
 		FC28CB31274609F300BA47BB /* TextUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextUseCase.swift; sourceTree = "<group>"; };
 		FC51FA66274BB9D60069D39C /* FontColorPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontColorPickerView.swift; sourceTree = "<group>"; };
 		FC51FA68274BBB3C0069D39C /* FontColorCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontColorCollectionViewCell.swift; sourceTree = "<group>"; };
-		FC51FA6A274C7D910069D39C /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		FC51FA6C274C89330069D39C /* FontSizeControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeControlView.swift; sourceTree = "<group>"; };
-		FC51FA6F274D4C4C0069D39C /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		FC5FB78F27325C4D008AC3D2 /* UserDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDocument.swift; sourceTree = "<group>"; };
 		FC5FB792273260C3008AC3D2 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 		FC5FB7942732627C008AC3D2 /* PairDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairDocument.swift; sourceTree = "<group>"; };
@@ -384,7 +382,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1D8646A7274D61BE00C4511D /* FirebaseMessaging in Frameworks */,
+				1D71B540274E0CD5000B50A8 /* FirebaseMessaging in Frameworks */,
 				664893F027300DB9009F03E2 /* Kingfisher in Frameworks */,
 				664893ED27300D7D009F03E2 /* SnapKit in Frameworks */,
 			);
@@ -569,7 +567,6 @@
 		664893B4273007ED009F03E2 = {
 			isa = PBXGroup;
 			children = (
-				FC51FA6F274D4C4C0069D39C /* Config.xcconfig */,
 				664893BF273007ED009F03E2 /* Doolda */,
 				1D9FAD4A2747B82B00198B93 /* Tests */,
 				664893BE273007ED009F03E2 /* Products */,
@@ -626,6 +623,7 @@
 				664893CB273007F1009F03E2 /* LaunchScreen.storyboard */,
 				664893CE273007F1009F03E2 /* Info.plist */,
 				665303992743B3FF00E3075C /* CoreDataModel.xcdatamodeld */,
+				1D71B53C274E0C36000B50A8 /* Config.xcconfig */,
 				1D99945F274C8E6300C72273 /* GoogleService-Info.plist */,
 			);
 			path = Resources;
@@ -843,14 +841,6 @@
 			path = PhotoFrames;
 			sourceTree = "<group>";
 		};
-		FC51FA6E274D301C0069D39C /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				FC51FA6A274C7D910069D39C /* Config.xcconfig */,
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -906,7 +896,7 @@
 			packageProductDependencies = (
 				664893EC27300D7D009F03E2 /* SnapKit */,
 				664893EF27300DB9009F03E2 /* Kingfisher */,
-				1D8646A6274D61BE00C4511D /* FirebaseMessaging */,
+				1D71B53F274E0CD5000B50A8 /* FirebaseMessaging */,
 			);
 			productName = Doolda;
 			productReference = 664893BD273007ED009F03E2 /* Doolda.app */;
@@ -947,7 +937,7 @@
 				664893EB27300D7D009F03E2 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				664893EE27300DB9009F03E2 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				664893F127300E28009F03E2 /* XCRemoteSwiftPackageReference "SwiftLint" */,
-				1D8646A5274D61BE00C4511D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				1D71B53E274E0CD5000B50A8 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 664893BE273007ED009F03E2 /* Products */;
 			projectDirPath = "";
@@ -983,9 +973,8 @@
 				66B4ADFF2742BEFC0021EA27 /* normal.jpg in Resources */,
 				66B4AE002742BEFC0021EA27 /* polaroid.jpg in Resources */,
 				66B4AE012742BEFC0021EA27 /* lifeFourCuts.jpg in Resources */,
-				FC51FA70274D4C4C0069D39C /* Config.xcconfig in Resources */,
+				1D71B53D274E0C36000B50A8 /* Config.xcconfig in Resources */,
 				664893CA273007F1009F03E2 /* Assets.xcassets in Resources */,
-				FC51FA6B274C7D910069D39C /* Config.xcconfig in Resources */,
 				1DD6AD4027321F7800592AC8 /* dovemayo.otf in Resources */,
 				1D999460274C8E6300C72273 /* GoogleService-Info.plist in Resources */,
 			);
@@ -1539,7 +1528,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		1D8646A5274D61BE00C4511D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+		1D71B53E274E0CD5000B50A8 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
@@ -1575,9 +1564,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		1D8646A6274D61BE00C4511D /* FirebaseMessaging */ = {
+		1D71B53F274E0CD5000B50A8 /* FirebaseMessaging */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 1D8646A5274D61BE00C4511D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = 1D71B53E274E0CD5000B50A8 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
 		};
 		664893EC27300D7D009F03E2 /* SnapKit */ = {

--- a/Doolda/Doolda/Application/AppDelegate.swift
+++ b/Doolda/Doolda/Application/AppDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by 정지승 on 2021/11/01.
 //
 
+import Combine
 import UIKit
 
 import Firebase
@@ -12,6 +13,9 @@ import FirebaseMessaging
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    
+    private var cancellables: Set<AnyCancellable> = []
+    
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -30,6 +34,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         return true
     }
+    
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
 }
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
@@ -38,6 +46,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
+        // FIXME: Background Notification에 대응할 코드가 작성되어야 함.
         print("RECEIVED")
     }
     
@@ -46,6 +55,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
+        // FIXME: Foreground Notification에 대응할 코드가 작성되어야 함.
         print("RECEIVED")
     }
 }
@@ -53,6 +63,28 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 extension AppDelegate: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         guard let token = fcmToken else { return }
-        print("FCM TOKEN : \(token)")
+        
+        // FIXME: 더 좋은 방법 찾아보기
+        let networkService = URLSessionNetworkService()
+        let persistenceService = UserDefaultsPersistenceService()
+        let userRepository: UserRepository = UserRepository(persistenceService: persistenceService, networkService: networkService)
+        let fcmTokenRepository: FCMTokenRepository = FCMTokenRepository(urlSessionNetworkService: networkService)
+        let getMyIdUseCase: GetMyIdUseCase = GetMyIdUseCase(userRepository: userRepository)
+        let fcmTokenUseCase: FCMTokenUseCase = FCMTokenUseCase(fcmTokenRepository: fcmTokenRepository)
+        
+        getMyIdUseCase.getMyId()
+            .compactMap { $0 }
+            .sink { [weak self] myId in
+                guard let self = self else { return }
+                fcmTokenUseCase.setToken(for: myId, with: token)
+                    .sink { completion in
+                        guard case .failure(let error) = completion else { return }
+                        print(error.localizedDescription)
+                    } receiveValue: { token in
+                        print("SUCCESS: \(token)")
+                    }
+                    .store(in: &self.cancellables)
+            }
+            .store(in: &self.cancellables)
     }
 }

--- a/Doolda/Doolda/Data/DataTransferObjects/UserDocument.swift
+++ b/Doolda/Doolda/Data/DataTransferObjects/UserDocument.swift
@@ -14,15 +14,21 @@ struct UserDocument: Codable {
     var pairId: String? {
         return self.fields["pairId"]?["stringValue"]
     }
+    var friendId: String? {
+        return self.fields["friendId"]?["stringValue"]
+    }
     
     let name: String
     let fields: [String: [String: String]]
     
-    init(userId: String, pairId: String) {
+    init(userId: String, pairId: String, friendId: String) {
         self.name = userId
         self.fields = [
             "pairId": [
                 "stringValue": pairId
+            ],
+            "friendId": [
+                "stringValue": friendId
             ]
         ]
     }
@@ -30,7 +36,8 @@ struct UserDocument: Codable {
     func toUser() -> User? {
         guard let userIdString = self.userId,
               let userDDID = DDID(from: userIdString),
-              let pairIdString = self.pairId else { return nil }
-        return User(id: userDDID, pairId: DDID(from: pairIdString))
+              let pairIdString = self.pairId,
+              let friendIdString = self.friendId else { return nil }
+        return User(id: userDDID, pairId: DDID(from: pairIdString), friendId: DDID(from: friendIdString))
     }
 }

--- a/Doolda/Doolda/Data/Repositories/FirebaseMessageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/FirebaseMessageRepository.swift
@@ -1,0 +1,22 @@
+//
+//  FirebaseMessageRepository.swift
+//  Doolda
+//
+//  Created by Seunghun Yang on 2021/11/23.
+//
+
+import Combine
+import Foundation
+
+class FirebaseMessageRepository: FirebaseMessageRepositoryProtocol {
+    private let urlSessionNetworkService: URLSessionNetworkServiceProtocol
+    
+    init(urlSessionNetworkService: URLSessionNetworkServiceProtocol) {
+        self.urlSessionNetworkService = urlSessionNetworkService
+    }
+    
+    func sendMessage(to token: String, title: String, body: String, data: [String : String]) -> AnyPublisher<[String : Any], Error> {
+        let request = FirebaseAPIs.sendFirebaseMessage(token, title, body, data)
+        return self.urlSessionNetworkService.request(request)
+    }
+}

--- a/Doolda/Doolda/Data/Repositories/UserRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/UserRepository.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum UserRepositoryError: LocalizedError {
     case nilUserId
+    case nilFriendId
     case DTOInitError
     case savePairIdFail
     
@@ -16,6 +17,8 @@ enum UserRepositoryError: LocalizedError {
         switch self {
         case .nilUserId:
             return "유저의 아이디가 존재하지 않습니다."
+        case .nilFriendId:
+            return "친구의 아이디가 존재하지 않습니다."
         case .DTOInitError:
             return "DataTransferObjects가 올바르지 않습니다."
         case .savePairIdFail:
@@ -60,8 +63,9 @@ class UserRepository: UserRepositoryProtocol {
             .eraseToAnyPublisher()
         }
         
+        guard let friendId = user.friendId else { return Fail(error: UserRepositoryError.nilFriendId).eraseToAnyPublisher() }
         let publisher: AnyPublisher<UserDocument, Error> =
-        self.urlSessionNetworkService.request(FirebaseAPIs.patchUserDocuement(user.id.ddidString, pairId.ddidString))
+        self.urlSessionNetworkService.request(FirebaseAPIs.patchUserDocument(user.id.ddidString, pairId.ddidString, friendId.ddidString))
         return publisher.tryMap { userDocument in
             guard let newUser = userDocument.toUser() else {
                 throw UserRepositoryError.nilUserId

--- a/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
@@ -34,16 +34,24 @@ class DiaryViewCoordinator: DiaryViewCoordinatorProtocol {
             fileManagerPersistenceService: fileManagerPersistenceService
         )
         
+        let fcmTokenRepository = FCMTokenRepository(urlSessionNetworkService: urlSessionNetworkService)
+        let firebaseMessageRepository = FirebaseMessageRepository(urlSessionNetworkService: urlSessionNetworkService)
+        
         let checkMyTurnUseCase = CheckMyTurnUseCase(pairRepository: pairRepository)
         let getPageUseCase = GetPageUseCase(pageRepository: pageRepository)
         let getRawPageUseCase = GetRawPageUseCase(rawPageRepository: rawPageRepository)
+        let firebaseMessageUseCase = FirebaseMessageUseCase(
+            fcmTokenRepository: fcmTokenRepository,
+            firebaseMessageRepository: firebaseMessageRepository
+        )
         
         let viewModel = DiaryViewModel(
             user: self.user,
             coordinator: self,
             checkMyTurnUseCase: checkMyTurnUseCase,
             getPageUseCase: getPageUseCase,
-            getRawPageUseCase: getRawPageUseCase
+            getRawPageUseCase: getRawPageUseCase,
+            firebaseMessageUseCase: firebaseMessageUseCase
         )
         
         DispatchQueue.main.async {

--- a/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
@@ -111,19 +111,22 @@ class DiaryViewModel: DiaryViewModelProtocol {
     private let checkMyTurnUseCase: CheckMyTurnUseCaseProtocol
     private let getPageUseCase: GetPageUseCaseProtocol
     private let getRawPageUseCase: GetRawPageUseCaseProtocol
+    private let firebaseMessageUseCase: FirebaseMessageUseCaseProtocol
     
     init(
         user: User,
         coordinator: DiaryViewCoordinatorProtocol,
         checkMyTurnUseCase: CheckMyTurnUseCaseProtocol,
         getPageUseCase: GetPageUseCaseProtocol,
-        getRawPageUseCase: GetRawPageUseCaseProtocol
+        getRawPageUseCase: GetRawPageUseCaseProtocol,
+        firebaseMessageUseCase: FirebaseMessageUseCaseProtocol
     ) {
         self.user = user
         self.coordinator = coordinator
         self.checkMyTurnUseCase = checkMyTurnUseCase
         self.getPageUseCase = getPageUseCase
         self.getRawPageUseCase = getRawPageUseCase
+        self.firebaseMessageUseCase = firebaseMessageUseCase
         self.bind()
     }
     
@@ -155,6 +158,9 @@ class DiaryViewModel: DiaryViewModelProtocol {
     
     func refreshButtonDidTap() {
         self.fetchPages()
+        
+        guard let friendId = self.user.friendId else { return }
+        self.firebaseMessageUseCase.sendMessage(to: friendId, message: PushMessageEntity.userRequestedNewPage)
     }
     
     func settingsButtonDidTap() {

--- a/Doolda/Doolda/Domain/Entities/PushMessageEntity.swift
+++ b/Doolda/Doolda/Domain/Entities/PushMessageEntity.swift
@@ -13,20 +13,21 @@ struct PushMessageEntity {
     let data: [String: String]
     
     static let userPairedWithFriend: PushMessageEntity = PushMessageEntity(
-        title: "안녕?! 🙋‍♀️🙋‍♂️",
+        title: "똑똑! 🙋‍♀️🙋‍♂️",
         body: "누군가가 당신을 친구로 연결했어요!",
         data: [:]
     )
     
+    // 이거 탭하는 경우엔 새로고쳐야할듯. 새로고침이 성공할 때에는 안보내야함.
     static let userPostedNewPage: PushMessageEntity = PushMessageEntity(
         title: "띵동! 🔔",
-        body: "친구가 다이어리를 작성했어요!",
+        body: "친구가 다이어리를 작성했어요!\n새 다이어리를 확인해볼까요?",
         data: [:]
     )
     
     static let userRequestedNewPage: PushMessageEntity = PushMessageEntity(
-        title: "쿡 쿡! 🥺👉🏻👉🏻",
-        body: "친구가 다이어리를 기다리고있어요.\n새 다이어리를 작성해주세요!",
+        title: "쿡쿡! 🥺👉🏻👉🏻",
+        body: "친구가 다이어리 작성을 기다리고있어요.\n새 다이어리를 작성해볼까요?",
         data: [:]
     )
 }

--- a/Doolda/Doolda/Domain/Entities/PushMessageEntity.swift
+++ b/Doolda/Doolda/Domain/Entities/PushMessageEntity.swift
@@ -1,0 +1,32 @@
+//
+//  PushMessageEntity.swift
+//  Doolda
+//
+//  Created by Seunghun Yang on 2021/11/23.
+//
+
+import Foundation
+
+struct PushMessageEntity {
+    let title: String
+    let body: String
+    let data: [String: String]
+    
+    static let userPairedWithFriend: PushMessageEntity = PushMessageEntity(
+        title: "안녕?! 🙋‍♀️🙋‍♂️",
+        body: "누군가가 당신을 친구로 연결했어요!",
+        data: [:]
+    )
+    
+    static let userPostedNewPage: PushMessageEntity = PushMessageEntity(
+        title: "띵동! 🔔",
+        body: "친구가 다이어리를 작성했어요!",
+        data: [:]
+    )
+    
+    static let userRequestedNewPage: PushMessageEntity = PushMessageEntity(
+        title: "쿡 쿡! 🥺👉🏻👉🏻",
+        body: "친구가 다이어리를 기다리고있어요.\n새 다이어리를 작성해주세요!",
+        data: [:]
+    )
+}

--- a/Doolda/Doolda/Domain/Entities/User.swift
+++ b/Doolda/Doolda/Domain/Entities/User.swift
@@ -10,14 +10,17 @@ import Foundation
 struct User: Hashable {
     let id: DDID
     var pairId: DDID?
+    var friendId: DDID?
     
-    init(id: DDID, pairId: DDID? = nil) {
+    init(id: DDID, pairId: DDID? = nil, friendId: DDID? = nil) {
         self.id = id
         self.pairId = pairId
+        self.friendId = friendId
     }
     
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
         hasher.combine(pairId)
+        hasher.combine(friendId)
     }
 }

--- a/Doolda/Doolda/Domain/Interfaces/FirebaseMessageRepositoryProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/FirebaseMessageRepositoryProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  FirebaseMessageRepository.swift
+//  Doolda
+//
+//  Created by Seunghun Yang on 2021/11/23.
+//
+
+import Combine
+import Foundation
+
+protocol FirebaseMessageRepositoryProtocol {
+    func sendMessage(to token: String, title: String, body: String, data: [String: String]) -> AnyPublisher<[String: Any], Error>
+}

--- a/Doolda/Doolda/Domain/UseCases/FirebaseMessageUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/FirebaseMessageUseCase.swift
@@ -12,7 +12,7 @@ protocol FirebaseMessageUseCaseProtocol {
     var errorPublisher: Published<Error?>.Publisher { get }
     var isMessageSentPublisher: Published<Bool?>.Publisher { get }
     
-    func sendMessage(to user: DDID, title: String, body: String, data: [String : String])
+    func sendMessage(to user: DDID, message: PushMessageEntity)
 }
 
 class FirebaseMessageUseCase: FirebaseMessageUseCaseProtocol {
@@ -32,14 +32,19 @@ class FirebaseMessageUseCase: FirebaseMessageUseCaseProtocol {
         self.firebaseMessageRepository = firebaseMessageRepository
     }
     
-    func sendMessage(to user: DDID, title: String, body: String, data: [String : String]) {
+    func sendMessage(to user: DDID, message: PushMessageEntity) {
         self.fcmTokenRepository.fetchToken(for: user)
             .sink { [weak self] completion in
                 guard case .failure(let error) = completion else { return }
                 self?.error = error
             } receiveValue: { [weak self] token in
                 guard let self = self else { return }
-                self.firebaseMessageRepository.sendMessage(to: token, title: title, body: body, data: data)
+                self.firebaseMessageRepository.sendMessage(
+                    to: token,
+                    title: message.title,
+                    body: message.body,
+                    data: message.data
+                )
                     .sink { [weak self] completion in
                         guard case .failure(let error) = completion else { return }
                         self?.error = error

--- a/Doolda/Doolda/Domain/UseCases/FirebaseMessageUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/FirebaseMessageUseCase.swift
@@ -10,14 +10,12 @@ import Foundation
 
 protocol FirebaseMessageUseCaseProtocol {
     var errorPublisher: Published<Error?>.Publisher { get }
-    var isMessageSentPublisher: Published<Bool?>.Publisher { get }
     
     func sendMessage(to user: DDID, message: PushMessageEntity)
 }
 
 class FirebaseMessageUseCase: FirebaseMessageUseCaseProtocol {
     var errorPublisher: Published<Error?>.Publisher { self.$error }
-    var isMessageSentPublisher: Published<Bool?>.Publisher { self.$isMessageSent }
     
     private let fcmTokenRepository: FCMTokenRepositoryProtocol
     private let firebaseMessageRepository: FirebaseMessageRepositoryProtocol
@@ -25,7 +23,6 @@ class FirebaseMessageUseCase: FirebaseMessageUseCaseProtocol {
     private var cancellables: Set<AnyCancellable> = []
     
     @Published private var error: Error?
-    @Published private var isMessageSent: Bool?
     
     init(fcmTokenRepository: FCMTokenRepositoryProtocol, firebaseMessageRepository: FirebaseMessageRepositoryProtocol) {
         self.fcmTokenRepository = fcmTokenRepository
@@ -48,9 +45,7 @@ class FirebaseMessageUseCase: FirebaseMessageUseCaseProtocol {
                     .sink { [weak self] completion in
                         guard case .failure(let error) = completion else { return }
                         self?.error = error
-                    } receiveValue: { [weak self] _ in
-                        self?.isMessageSent = true
-                    }
+                    } receiveValue: { _ in }
                     .store(in: &self.cancellables)
             }
             .store(in: &self.cancellables)

--- a/Doolda/Doolda/Domain/UseCases/FirebaseMessageUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/FirebaseMessageUseCase.swift
@@ -1,0 +1,53 @@
+//
+//  FirebaseMessageUseCase.swift
+//  Doolda
+//
+//  Created by Seunghun Yang on 2021/11/23.
+//
+
+import Combine
+import Foundation
+
+protocol FirebaseMessageUseCaseProtocol {
+    var errorPublisher: Published<Error?>.Publisher { get }
+    var isMessageSentPublisher: Published<Bool?>.Publisher { get }
+    
+    func sendMessage(to user: DDID, title: String, body: String, data: [String : String])
+}
+
+class FirebaseMessageUseCase: FirebaseMessageUseCaseProtocol {
+    var errorPublisher: Published<Error?>.Publisher { self.$error }
+    var isMessageSentPublisher: Published<Bool?>.Publisher { self.$isMessageSent }
+    
+    private let fcmTokenRepository: FCMTokenRepositoryProtocol
+    private let firebaseMessageRepository: FirebaseMessageRepositoryProtocol
+    
+    private var cancellables: Set<AnyCancellable> = []
+    
+    @Published private var error: Error?
+    @Published private var isMessageSent: Bool?
+    
+    init(fcmTokenRepository: FCMTokenRepositoryProtocol, firebaseMessageRepository: FirebaseMessageRepositoryProtocol) {
+        self.fcmTokenRepository = fcmTokenRepository
+        self.firebaseMessageRepository = firebaseMessageRepository
+    }
+    
+    func sendMessage(to user: DDID, title: String, body: String, data: [String : String]) {
+        self.fcmTokenRepository.fetchToken(for: user)
+            .sink { [weak self] completion in
+                guard case .failure(let error) = completion else { return }
+                self?.error = error
+            } receiveValue: { [weak self] token in
+                guard let self = self else { return }
+                self.firebaseMessageRepository.sendMessage(to: token, title: title, body: body, data: data)
+                    .sink { [weak self] completion in
+                        guard case .failure(let error) = completion else { return }
+                        self?.error = error
+                    } receiveValue: { [weak self] _ in
+                        self?.isMessageSent = true
+                    }
+                    .store(in: &self.cancellables)
+            }
+            .store(in: &self.cancellables)
+    }
+}

--- a/Doolda/Doolda/Domain/UseCases/PairUserUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/PairUserUseCase.swift
@@ -117,8 +117,8 @@ final class PairUserUseCase: PairUserUseCaseProtocol {
                       case .failure = completion else { return }
                 
                 let pairId = DDID()
-                let user = User(id: user.id, pairId: pairId)
-                let friend = User(id: friend.id, pairId: pairId)
+                let user = User(id: user.id, pairId: pairId, friendId: friend.id)
+                let friend = User(id: friend.id, pairId: pairId, friendId: user.id)
                 
                 Publishers.Zip3(
                     self.userRepository.setUser(user),

--- a/Doolda/Doolda/Domain/UseCases/PairUserUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/PairUserUseCase.swift
@@ -76,8 +76,7 @@ final class PairUserUseCase: PairUserUseCaseProtocol {
     }
 
     func pair(user: User) {
-        let pairId = user.id
-        let user = User(id: user.id, pairId: pairId)
+        let user = User(id: user.id, pairId: user.id, friendId: user.id)
 
         Publishers.Zip(
             self.userRepository.setUser(user),

--- a/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
@@ -39,6 +39,8 @@ class EditPageViewCoordinator: EditPageViewCoordinatorProtocol {
                 networkService: urlSessionNetworkService,
                 fileManagerPersistenceService: fileManagerPersistenceService
             )
+            let fcmTokenRepository = FCMTokenRepository(urlSessionNetworkService: urlSessionNetworkService)
+            let firebaseMessageRepository = FirebaseMessageRepository(urlSessionNetworkService: urlSessionNetworkService)
             
             let imageUseCase = ImageUseCase(imageRepository: imageRepository)
             let editPageUseCase = EditPageUseCase(
@@ -48,8 +50,17 @@ class EditPageViewCoordinator: EditPageViewCoordinatorProtocol {
                 rawPageRepository: rawPageRepository,
                 pairRepository: pairRepository
             )
+            let firebaseMessageUseCase = FirebaseMessageUseCase(
+                fcmTokenRepository: fcmTokenRepository,
+                firebaseMessageRepository: firebaseMessageRepository
+            )
             
-            let editPageViewModel = EditPageViewModel(user: self.user, coordinator: self, editPageUseCase: editPageUseCase)
+            let editPageViewModel = EditPageViewModel(
+                user: self.user,
+                coordinator: self,
+                editPageUseCase: editPageUseCase,
+                firebaseMessageUseCase: firebaseMessageUseCase
+            )
             
             let viewController = EditPageViewController(viewModel: editPageViewModel)
             self.presenter.pushViewController(viewController, animated: true)

--- a/Doolda/Doolda/EditPageScene/EditPageViewModel.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewModel.swift
@@ -52,6 +52,8 @@ final class EditPageViewModel: EditPageViewModelProtocol {
     private let user: User
     private let coordinator: EditPageViewCoordinatorProtocol
     private let editPageUseCase: EditPageUseCaseProtocol
+    private let firebaseMessageUseCase: FirebaseMessageUseCaseProtocol
+    
     private var cancellables: Set<AnyCancellable> = []
     
     @Published private var selectedComponent: ComponentEntity? = nil
@@ -62,11 +64,13 @@ final class EditPageViewModel: EditPageViewModelProtocol {
     init(
         user: User,
         coordinator: EditPageViewCoordinatorProtocol,
-        editPageUseCase: EditPageUseCaseProtocol
+        editPageUseCase: EditPageUseCaseProtocol,
+        firebaseMessageUseCase: FirebaseMessageUseCaseProtocol
     ) {
         self.user = user
         self.coordinator = coordinator
         self.editPageUseCase = editPageUseCase
+        self.firebaseMessageUseCase = firebaseMessageUseCase
         bind()
     }
     
@@ -87,6 +91,8 @@ final class EditPageViewModel: EditPageViewModelProtocol {
         self.editPageUseCase.resultPublisher
             .dropFirst()
             .sink { [weak self] _ in
+                guard let friendId = self?.user.friendId else { return }
+                self?.firebaseMessageUseCase.sendMessage(to: friendId, message: PushMessageEntity.userPostedNewPage)
                 self?.coordinator.editingPageSaved()
             }.store(in: &self.cancellables)
         

--- a/Doolda/Doolda/PairingScene/PairingViewCoordinator.swift
+++ b/Doolda/Doolda/PairingScene/PairingViewCoordinator.swift
@@ -26,15 +26,22 @@ class PairingViewCoordinator: PairingViewCoordinatorProtocol {
         )
         
         let pairRepository = PairRepository(networkService: urlSessionNetworkService)
+        let fcmTokenRepository = FCMTokenRepository(urlSessionNetworkService: urlSessionNetworkService)
+        let firebaseMessageRepository = FirebaseMessageRepository(urlSessionNetworkService: urlSessionNetworkService)
 
         let pairUserUseCase = PairUserUseCase(userRepository: userRepository, pairRepository: pairRepository)
         let refreshUserUseCase = RefreshUserUseCase(userRepository: userRepository)
+        let firebaseMessageUseCase = FirebaseMessageUseCase(
+            fcmTokenRepository: fcmTokenRepository,
+            firebaseMessageRepository: firebaseMessageRepository
+        )
 
         let viewModel = PairingViewModel(
             user: user,
             coordinator: self,
             pairUserUseCase: pairUserUseCase,
-            refreshUserUseCase: refreshUserUseCase
+            refreshUserUseCase: refreshUserUseCase,
+            firebaseMessageUseCase: firebaseMessageUseCase
         )
 
         DispatchQueue.main.async {

--- a/Doolda/Doolda/Support/Constants/API.swift
+++ b/Doolda/Doolda/Support/Constants/API.swift
@@ -10,7 +10,7 @@ import Foundation
 enum FirebaseAPIs: URLRequestBuilder {
     case getUserDocuement(String)
     case createUserDocument(String)
-    case patchUserDocuement(String, String)
+    case patchUserDocument(String, String, String)
     
     case getPairDocument(String)
     case createPairDocument(String, String)
@@ -44,7 +44,7 @@ extension FirebaseAPIs {
 extension FirebaseAPIs {
     var path: String? {
         switch self {
-        case .getUserDocuement(let userId), .patchUserDocuement(let userId, _):
+        case .getUserDocuement(let userId), .patchUserDocument(let userId, _, _):
             return "documents/user/\(userId)"
         case .createUserDocument:
             return "documents/user"
@@ -72,7 +72,7 @@ extension FirebaseAPIs {
             return ["documentId": id]
         case .createPageDocument(_, _, let jsonPath, let pairId):
             return ["documentId": pairId + jsonPath]
-        case .patchUserDocuement, .patchPairDocument:
+        case .patchUserDocument, .patchPairDocument:
             return ["currentDocument.exists": "true"]
         case .uploadDataFile, .downloadDataFile:
             return ["alt": "media"]
@@ -87,7 +87,7 @@ extension FirebaseAPIs {
             return .get
         case .createUserDocument, .createPairDocument, .createPageDocument, .uploadDataFile, .getPageDocuments, .sendFirebaseMessage:
             return .post
-        case .patchUserDocuement, .patchPairDocument, .patchFCMTokenDocument:
+        case .patchUserDocument, .patchPairDocument, .patchFCMTokenDocument:
             return .patch
         }
     }
@@ -154,12 +154,12 @@ extension FirebaseAPIs {
                 ]
             ]
         case .createUserDocument(let userId):
-            let userDocument = UserDocument(userId: userId, pairId: "")
+            let userDocument = UserDocument(userId: userId, pairId: "", friendId: "")
             return [
                 "fields": userDocument.fields
             ]
-        case .patchUserDocuement(let userId, let pairId):
-            let userDocument = UserDocument(userId: userId, pairId: pairId)
+        case .patchUserDocument(let userId, let pairId, let friendId):
+            let userDocument = UserDocument(userId: userId, pairId: pairId, friendId: friendId)
             return [
                 "fields": userDocument.fields
             ]


### PR DESCRIPTION
## 이슈 목록
- [x] #363 
- [x] #367 
- [x] #368 
- [x] #369 
- [x] #370 

## 특이사항
* `AppDelegate` 에서 유저정보와 Token을 모두확인해서 매번 새롭게 Set해주고있는데 이전에 이야기했듯 별로 좋지 않은 방식같아 개선이 필요하다.
* Foreground와 Background에 메시지가 들어올때 몇몇 작업들을 해줘야한다. (보통은 새로고침) 아직 미구현된 부분
* Foreground에서 노티가 보여지지않는다. (기본적으로 애플이 제공안함) 그래서 커스텀뷰를 만들어야한다!!

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

