### PR TITLE
페이지 캐싱 문제 수정

### DIFF
--- a/Doolda/Doolda/Data/Interfaces/CoreDataPageEntityPersistenceServiceProtocol.swift
+++ b/Doolda/Doolda/Data/Interfaces/CoreDataPageEntityPersistenceServiceProtocol.swift
@@ -11,6 +11,6 @@ import Foundation
 protocol CoreDataPageEntityPersistenceServiceProtocol {
     func isPageEntityUpToDate(_ pageEntity: PageEntity) -> AnyPublisher<Bool, Error>
     func fetchPageEntities() -> AnyPublisher<[PageEntity], Error>
-    func savePageEntity(_ pageEntity: PageEntity) -> AnyPublisher<Void, Error>
+    func savePageEntity(_ pageEntity: PageEntity) -> AnyPublisher<PageEntity, Error>
     func removeAllPageEntity() -> AnyPublisher<Void, Error>
 }

--- a/Doolda/Doolda/Data/Repositories/PageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PageRepository.swift
@@ -12,11 +12,13 @@ import OSLog
 enum PageRepositoryError: LocalizedError {
     case userNotPaired
     case failedToFetchPages
+    case failedToUpdatePage
     
     var errorDescription: String? {
         switch self {
         case .userNotPaired: return "페어링 된 유저가 없습니다."
         case .failedToFetchPages: return "페이지 패치에 실패했습니다."
+        case .failedToUpdatePage: return "페이지 업데이트에 실패했습니다."
         }
     }
 }
@@ -46,25 +48,68 @@ class PageRepository: PageRepositoryProtocol {
     }
     
     func updatePage(_ page: PageEntity) -> AnyPublisher<PageEntity, Error> {
-        guard let pairId = page.author.pairId?.ddidString else { return Fail(error: PageRepositoryError.userNotPaired).eraseToAnyPublisher() }
-        let request = FirebaseAPIs.patchPageDocument(page.author.id.ddidString, page.createdTime, page.updatedTime, page.jsonPath, pairId)
-        let publisher: AnyPublisher<[String: Any], Error> = self.urlSessionNetworkService.request(request)
-        
-        return publisher
-            .map { [weak self] _ -> PageEntity in
-                self?.savePageToCache(pages: [page])
-                return page
+        return Future { [weak self] promise in
+            guard let pairId = page.author.pairId?.ddidString else {
+                return promise(.failure(PageRepositoryError.userNotPaired))
             }
-            .eraseToAnyPublisher()
+            
+            guard let self = self else {
+                return promise(.failure(PageRepositoryError.failedToUpdatePage))
+            }
+            
+            let request = FirebaseAPIs.patchPageDocument(page.author.id.ddidString, page.createdTime, page.updatedTime, page.jsonPath, pairId)
+            let publisher: AnyPublisher<[String: Any], Error> = self.urlSessionNetworkService.request(request)
+            
+            publisher
+                .sink { completion in
+                    guard case .failure(let error) = completion else { return }
+                    promise(.failure(error))
+                } receiveValue: { [weak self] _ in
+                    guard let self = self else {
+                        return promise(.failure(PageRepositoryError.failedToUpdatePage))
+                    }
+                    
+                    self.savePageToCache(pages: [page])
+                        .sink { completion in
+                            guard case .failure(let error) = completion else { return }
+                            promise(.failure(error))
+                        } receiveValue: { _ in
+                            promise(.success(page))
+                        }
+                        .store(in: &self.cancellables)
+                }
+                .store(in: &self.cancellables)
+        }
+        .eraseToAnyPublisher()
     }
     
     func fetchPages(for pair: DDID) -> AnyPublisher<[PageEntity], Error> {
-        return self.fetchPageFromServer(pairId: pair, after: nil)
-            .map { pages -> [PageEntity] in
-                self.savePageToCache(pages: pages)
-                return pages
+        return Future { [weak self] promise in
+            guard let self = self else {
+                return promise(.failure(PageRepositoryError.failedToFetchPages))
             }
-            .eraseToAnyPublisher()
+
+            self.fetchPageFromServer(pairId: pair, after: nil)
+                .sink(receiveCompletion: { completion in
+                    guard case .failure(let error) = completion else { return }
+                    promise(.failure(error))
+                }, receiveValue: { [weak self] pages in
+                    guard let self = self else {
+                        return promise(.failure(PageRepositoryError.failedToFetchPages))
+                    }
+
+                    self.savePageToCache(pages: pages)
+                        .sink(receiveCompletion: { completion in
+                            guard case .failure(let error) = completion else { return }
+                            promise(.failure(error))
+                        }, receiveValue: { _ in
+                            promise(.success(pages))
+                        })
+                        .store(in: &self.cancellables)
+                })
+                .store(in: &self.cancellables)
+        }
+        .eraseToAnyPublisher()
     }
     
     private func fetchPageFromServer(pairId: DDID, after: Date?) -> AnyPublisher<[PageEntity], Error> {
@@ -85,15 +130,12 @@ class PageRepository: PageRepositoryProtocol {
             .eraseToAnyPublisher()
     }
     
-    private func savePageToCache(pages: [PageEntity]) {
+    private func savePageToCache(pages: [PageEntity]) -> AnyPublisher<Void, Error> {
         let savePublishers = pages.map { self.pageEntityPersistenceService.savePageEntity($0) }
         
-        Publishers.MergeMany(savePublishers)
+        return Publishers.MergeMany(savePublishers)
             .collect()
-            .sink { completion in
-                guard case .failure = completion else { return }
-                os_log("PageEntity caching failure", type: .fault)
-            } receiveValue: { _ in }
-            .store(in: &self.cancellables)
+            .map { _ -> Void in () }
+            .eraseToAnyPublisher()
     }
 }

--- a/Doolda/Doolda/Service/CoreData/CoreDataPageEntityPersistenceService.swift
+++ b/Doolda/Doolda/Service/CoreData/CoreDataPageEntityPersistenceService.swift
@@ -76,7 +76,7 @@ class CoreDataPageEntityPersistenceService: CoreDataPageEntityPersistenceService
         .eraseToAnyPublisher()
     }
     
-    func savePageEntity(_ pageEntity: PageEntity) -> AnyPublisher<Void, Error> {
+    func savePageEntity(_ pageEntity: PageEntity) -> AnyPublisher<PageEntity, Error> {
         guard let context = coreDataPersistenceService.backgroundContext,
               let coreDataPageEntity = NSEntityDescription.entity(forEntityName: CoreDataPageEntity.coreDataPageEntityName, in: context) else {
             return Fail(error: CoreDataPageEntityPersistenceServiceError.failedToInitializeCoreDataContainer).eraseToAnyPublisher()
@@ -102,7 +102,7 @@ class CoreDataPageEntityPersistenceService: CoreDataPageEntityPersistenceService
                     if context.hasChanges {
                         try context.save()
                     }
-                    promise(.success(()))
+                    promise(.success(pageEntity))
                 } catch {
                     promise(.failure(error))
                 }


### PR DESCRIPTION
## 이슈 목록
- [ ] #405 

## 특이사항
* 페이지가 새로 생성될 때 무작위로 페이지가 로딩되지 않는 현상을 수정했습니다.
* 페이지 패치시 캐싱과 패치 결과를 동시에 흘리고 있었습니다.
* 캐싱이 완료되기 전에 패치 결과를 사용해 서버에서 데이터를 가져오려고 시도했고 중간에 오류가 생겨서 스트림이 끊겼었습니다.
* rawPageEntity를 가져오는 로직에 캐시 데이터를 참조(최신 데이터인지 확인하는 과정)하는데 이때 캐시에 데이터를 찾지 못해서 오류가 발생했습니다.
* 캐싱이 완료되어야 패치 결과를 스트림에 흘리도록 수정했습니다.

## 더간단한 해결방법
* 수정되기 전 코드를 유지하고, rawPageEntity를 가져오는 로직에 PageEntity의 캐시 데이터가 존재하지 않는다면 디스크에 캐싱된 파일이 없다고 가정하고 새롭게 서버에서 jsonPath를 다운로드 받는 방법도 있습니다.

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

