### PR TITLE
일부 색상이 누락된 문제, 네비게이션 바 타이틀이 초기에 설정안되는 문제 해결

### DIFF
--- a/Doolda/Doolda/Common/CustomActivityIndicator.swift
+++ b/Doolda/Doolda/Common/CustomActivityIndicator.swift
@@ -23,7 +23,7 @@ final class CustomActivityIndicator: UIView {
     
     private lazy var activityIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView()
-        indicator.color = .dooldaSubLabel
+        indicator.color = .dooldaSublabel
         indicator.hidesWhenStopped = false
         return indicator
     }()
@@ -32,7 +32,7 @@ final class CustomActivityIndicator: UIView {
         let label = UILabel()
         label.font = .systemFont(ofSize: 14)
         label.textAlignment = .center
-        label.textColor = .dooldaSubLabel
+        label.textColor = .dooldaSublabel
         return label
     }()
     

--- a/Doolda/Doolda/DiaryScene/DiaryBackgroundView.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryBackgroundView.swift
@@ -27,7 +27,7 @@ class DiaryBackgroundView: UIView {
     private lazy var subtitleLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
-        label.textColor = .dooldaSubLabel
+        label.textColor = .dooldaSublabel
         return label
     }()
     

--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -82,13 +82,6 @@ class DiaryViewController: UIViewController {
         return generator
     }()
     
-    private lazy var transparentNavigationBarAppearance: UINavigationBarAppearance = {
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .clear
-        appearance.configureWithTransparentBackground()
-        return appearance
-    }()
-    
     private var headerView: DiaryCollectionViewHeader?
     
     // MARK: - Override Properties
@@ -136,6 +129,7 @@ class DiaryViewController: UIViewController {
         self.view.backgroundColor = .dooldaBackground
         self.title = "둘다"
         
+        self.navigationController?.navigationBar.isHidden = false
         self.navigationController?.navigationBar.barTintColor = .dooldaBackground
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.settingsButton)
         self.navigationItem.leftBarButtonItems = [
@@ -150,9 +144,7 @@ class DiaryViewController: UIViewController {
     }
     
     private func configureFont() {
-        self.transparentNavigationBarAppearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
-        self.navigationController?.navigationBar.standardAppearance = self.transparentNavigationBarAppearance
-        self.navigationController?.navigationBar.scrollEdgeAppearance = self.transparentNavigationBarAppearance
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
         self.pageCollectionBackgroundView.titleFont = .systemFont(ofSize: 35)
         self.pageCollectionBackgroundView.subtitleFont = .systemFont(ofSize: 20)
     }

--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -150,7 +150,7 @@ class DiaryViewController: UIViewController {
     }
     
     private func configureFont() {
-        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 20)]
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
         self.pageCollectionBackgroundView.titleFont = .systemFont(ofSize: 35)
         self.pageCollectionBackgroundView.subtitleFont = .systemFont(ofSize: 20)
     }

--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -77,16 +77,16 @@ class DiaryViewController: UIViewController {
         return button
     }()
     
-    private let transparentNavigationBarAppearance: UINavigationBarAppearance = {
+    private lazy var hapticGenerator: UIImpactFeedbackGenerator = {
+        let generator = UIImpactFeedbackGenerator(style: .heavy)
+        return generator
+    }()
+    
+    private lazy var transparentNavigationBarAppearance: UINavigationBarAppearance = {
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = .clear
         appearance.configureWithTransparentBackground()
         return appearance
-    }()
-    
-    private lazy var hapticGenerator: UIImpactFeedbackGenerator = {
-        let generator = UIImpactFeedbackGenerator(style: .heavy)
-        return generator
     }()
     
     private var headerView: DiaryCollectionViewHeader?
@@ -150,7 +150,9 @@ class DiaryViewController: UIViewController {
     }
     
     private func configureFont() {
-        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
+        self.transparentNavigationBarAppearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
+        self.navigationController?.navigationBar.standardAppearance = self.transparentNavigationBarAppearance
+        self.navigationController?.navigationBar.scrollEdgeAppearance = self.transparentNavigationBarAppearance
         self.pageCollectionBackgroundView.titleFont = .systemFont(ofSize: 35)
         self.pageCollectionBackgroundView.subtitleFont = .systemFont(ofSize: 20)
     }

--- a/Doolda/Doolda/EditPageScene/EditPageViewController.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewController.swift
@@ -91,13 +91,6 @@ class EditPageViewController: UIViewController {
         return generator
     }()
     
-    private lazy var transparentNavigationBarAppearance: UINavigationBarAppearance = {
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .clear
-        appearance.configureWithTransparentBackground()
-        return appearance
-    }()
-    
     // MARK: - Override Properties
     
     override var prefersStatusBarHidden: Bool { return true }
@@ -213,9 +206,7 @@ class EditPageViewController: UIViewController {
     }
     
     private func configureFont() {
-        self.transparentNavigationBarAppearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
-        self.navigationController?.navigationBar.standardAppearance = self.transparentNavigationBarAppearance
-        self.navigationController?.navigationBar.scrollEdgeAppearance = self.transparentNavigationBarAppearance
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
     }
     
     private func bindUI() {

--- a/Doolda/Doolda/EditPageScene/EditPageViewController.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewController.swift
@@ -91,6 +91,13 @@ class EditPageViewController: UIViewController {
         return generator
     }()
     
+    private lazy var transparentNavigationBarAppearance: UINavigationBarAppearance = {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = .clear
+        appearance.configureWithTransparentBackground()
+        return appearance
+    }()
+    
     // MARK: - Override Properties
     
     override var prefersStatusBarHidden: Bool { return true }
@@ -206,9 +213,9 @@ class EditPageViewController: UIViewController {
     }
     
     private func configureFont() {
-        self.navigationController?.navigationBar.titleTextAttributes = [
-            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16) as Any
-        ]
+        self.transparentNavigationBarAppearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
+        self.navigationController?.navigationBar.standardAppearance = self.transparentNavigationBarAppearance
+        self.navigationController?.navigationBar.scrollEdgeAppearance = self.transparentNavigationBarAppearance
     }
     
     private func bindUI() {

--- a/Doolda/Doolda/EditPageScene/EditPageViewController.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewController.swift
@@ -207,7 +207,7 @@ class EditPageViewController: UIViewController {
     
     private func configureFont() {
         self.navigationController?.navigationBar.titleTextAttributes = [
-            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17) as Any
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16) as Any
         ]
     }
     

--- a/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
+++ b/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
@@ -37,6 +37,13 @@ class PageDetailViewController: UIViewController {
         return activityIndicator
     }()
     
+    private lazy var transparentNavigationBarAppearance: UINavigationBarAppearance = {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = .clear
+        appearance.configureWithTransparentBackground()
+        return appearance
+    }()
+    
     // MARK: - Private Properties
 
     private var viewModel: PageDetailViewModelProtocol!
@@ -242,6 +249,8 @@ class PageDetailViewController: UIViewController {
     }
     
     private func configureFont() {
-        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
+        self.transparentNavigationBarAppearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
+        self.navigationController?.navigationBar.standardAppearance = self.transparentNavigationBarAppearance
+        self.navigationController?.navigationBar.scrollEdgeAppearance = self.transparentNavigationBarAppearance
     }
 }

--- a/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
+++ b/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
@@ -242,6 +242,6 @@ class PageDetailViewController: UIViewController {
     }
     
     private func configureFont() {
-        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17)]
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
     }
 }

--- a/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
+++ b/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
@@ -37,13 +37,6 @@ class PageDetailViewController: UIViewController {
         return activityIndicator
     }()
     
-    private lazy var transparentNavigationBarAppearance: UINavigationBarAppearance = {
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .clear
-        appearance.configureWithTransparentBackground()
-        return appearance
-    }()
-    
     // MARK: - Private Properties
 
     private var viewModel: PageDetailViewModelProtocol!
@@ -249,8 +242,6 @@ class PageDetailViewController: UIViewController {
     }
     
     private func configureFont() {
-        self.transparentNavigationBarAppearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
-        self.navigationController?.navigationBar.standardAppearance = self.transparentNavigationBarAppearance
-        self.navigationController?.navigationBar.scrollEdgeAppearance = self.transparentNavigationBarAppearance
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
     }
 }

--- a/Doolda/Doolda/PairingScene/PairingViewController.swift
+++ b/Doolda/Doolda/PairingScene/PairingViewController.swift
@@ -74,7 +74,6 @@ class PairingViewController: UIViewController {
         let button = DooldaButton()
         button.setTitle("연결하기", for: .normal)
         button.setTitleColor(.dooldaLabel, for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 14)
         button.backgroundColor = .dooldaHighlighted
         button.isEnabled = false
         return button
@@ -84,7 +83,6 @@ class PairingViewController: UIViewController {
         let button = DooldaButton()
         button.setTitle("혼자 쓰러가기", for: .normal)
         button.setTitleColor(.dooldaLabel, for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 14)
         button.backgroundColor = .dooldaHighlighted
         return button
     }()
@@ -218,8 +216,8 @@ class PairingViewController: UIViewController {
         self.myIdLabel.font = .systemFont(ofSize: 16)
         self.friendIdTitleLabel.font = .systemFont(ofSize: 14)
         self.friendIdTextField.font = .systemFont(ofSize: 16)
-        self.pairButton.titleLabel?.font = .systemFont(ofSize: 16)
-        self.pairSkipButton.titleLabel?.font = .systemFont(ofSize: 16)
+        self.pairButton.titleLabel?.font = .systemFont(ofSize: 14)
+        self.pairSkipButton.titleLabel?.font = .systemFont(ofSize: 14)
     }
     
     private func bindUI() {

--- a/Doolda/Doolda/PairingScene/PairingViewController.swift
+++ b/Doolda/Doolda/PairingScene/PairingViewController.swift
@@ -61,10 +61,6 @@ class PairingViewController: UIViewController {
     
     private lazy var friendIdTextField: UITextField = {
         let textField = UITextField()
-        textField.attributedPlaceholder = NSAttributedString(
-            string: "전달 받은 초대코드 입력",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.dooldaPlaceholder as Any]
-        )
         textField.textColor = .dooldaLabel
         textField.textAlignment = .center
         return textField

--- a/Doolda/Doolda/PairingScene/PairingViewController.swift
+++ b/Doolda/Doolda/PairingScene/PairingViewController.swift
@@ -105,7 +105,7 @@ class PairingViewController: UIViewController {
         return stackView
     }()
     
-    private let transparentNavigationBarAppearance: UINavigationBarAppearance = {
+    private lazy var transparentNavigationBarAppearance: UINavigationBarAppearance = {
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = .clear
         appearance.configureWithTransparentBackground()
@@ -136,12 +136,6 @@ class PairingViewController: UIViewController {
         self.configureUI()
         self.configureFont()
         self.bindUI()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationController?.navigationBar.standardAppearance = transparentNavigationBarAppearance
-        self.navigationController?.navigationBar.scrollEdgeAppearance = transparentNavigationBarAppearance
     }
     
     // MARK: - Helpers
@@ -206,6 +200,9 @@ class PairingViewController: UIViewController {
     }
     
     private func configureFont() {
+        self.transparentNavigationBarAppearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
+        self.navigationController?.navigationBar.standardAppearance = self.transparentNavigationBarAppearance
+        self.navigationController?.navigationBar.scrollEdgeAppearance = self.transparentNavigationBarAppearance
         self.logoLabel.font = UIFont(name: FontType.dovemayo.name, size: 72)
         self.instructionLabel.font = .systemFont(ofSize: 18)
         self.myIdTitleLabel.font = .systemFont(ofSize: 14)

--- a/Doolda/Doolda/PairingScene/PairingViewController.swift
+++ b/Doolda/Doolda/PairingScene/PairingViewController.swift
@@ -39,7 +39,7 @@ class PairingViewController: UIViewController {
     
     private lazy var myIdTitleLabel: UILabel = {
         let label = UILabel()
-        label.textColor = .dooldaSubLabel
+        label.textColor = .dooldaSublabel
         label.text = "내 초대코드"
         return label
     }()
@@ -54,7 +54,7 @@ class PairingViewController: UIViewController {
     
     private lazy var friendIdTitleLabel: UILabel = {
         let label = UILabel()
-        label.textColor = .dooldaSubLabel
+        label.textColor = .dooldaSublabel
         label.text = "상대방 초대코드를 전달 받으셨나요?"
         return label
     }()
@@ -91,7 +91,7 @@ class PairingViewController: UIViewController {
     
     private lazy var divider: UIView = {
         let view = UIView()
-        view.backgroundColor = .dooldaSubLabel
+        view.backgroundColor = .dooldaSublabel
         return view
     }()
     
@@ -327,5 +327,4 @@ class PairingViewController: UIViewController {
         )
         self.present(alert, animated: true)
     }
-
 }

--- a/Doolda/Doolda/PairingScene/PairingViewController.swift
+++ b/Doolda/Doolda/PairingScene/PairingViewController.swift
@@ -105,13 +105,6 @@ class PairingViewController: UIViewController {
         return stackView
     }()
     
-    private lazy var transparentNavigationBarAppearance: UINavigationBarAppearance = {
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .clear
-        appearance.configureWithTransparentBackground()
-        return appearance
-    }()
-    
     private lazy var hapticGenerator: UIImpactFeedbackGenerator = {
         let generator = UIImpactFeedbackGenerator(style: .heavy)
         return generator
@@ -142,11 +135,17 @@ class PairingViewController: UIViewController {
     
     private func configureUI() {
         self.view.backgroundColor = .dooldaBackground
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.refreshButton)
+        self.navigationController?.navigationBar.isHidden = true
         
         self.view.addSubview(scrollView)
         self.scrollView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
+        }
+        
+        self.view.addSubview(self.refreshButton)
+        self.refreshButton.snp.makeConstraints { make in
+            make.top.equalTo(self.view.safeAreaLayoutGuide).offset(16)
+            make.trailing.equalToSuperview().offset(-16)
         }
         
         self.scrollView.addSubview(contentView)
@@ -200,9 +199,6 @@ class PairingViewController: UIViewController {
     }
     
     private func configureFont() {
-        self.transparentNavigationBarAppearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
-        self.navigationController?.navigationBar.standardAppearance = self.transparentNavigationBarAppearance
-        self.navigationController?.navigationBar.scrollEdgeAppearance = self.transparentNavigationBarAppearance
         self.logoLabel.font = UIFont(name: FontType.dovemayo.name, size: 72)
         self.instructionLabel.font = .systemFont(ofSize: 18)
         self.myIdTitleLabel.font = .systemFont(ofSize: 14)

--- a/Doolda/Doolda/SettingsScene/SettingsTableViewHeader.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsTableViewHeader.swift
@@ -20,7 +20,7 @@ class SettingsTableViewHeader: UITableViewHeaderFooterView {
 
     private lazy var titleLabel: UILabel = {
         let title = UILabel()
-        title.textColor = .dooldaSubLabel
+        title.textColor = .dooldaSublabel
         return title
     }()
 

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -21,13 +21,6 @@ class SettingsViewController: UIViewController {
         let cell: SettingsTableViewCell
         let handler: (() -> Void)?
     }
-    
-    private lazy var transparentNavigationBarAppearance: UINavigationBarAppearance = {
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .clear
-        appearance.configureWithTransparentBackground()
-        return appearance
-    }()
 
     // MARK: - Subviews
 
@@ -119,9 +112,7 @@ class SettingsViewController: UIViewController {
     }
 
     private func configureFont() {
-        self.transparentNavigationBarAppearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
-        self.navigationController?.navigationBar.standardAppearance = self.transparentNavigationBarAppearance
-        self.navigationController?.navigationBar.scrollEdgeAppearance = self.transparentNavigationBarAppearance
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
 
         self.settingsSections.enumerated().forEach { index, section in
             guard let header = self.tableView.headerView(forSection: index) as? SettingsTableViewHeader else { return }

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -112,7 +112,7 @@ class SettingsViewController: UIViewController {
     }
 
     private func configureFont() {
-        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17)]
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
 
         self.settingsSections.enumerated().forEach { index, section in
             guard let header = self.tableView.headerView(forSection: index) as? SettingsTableViewHeader else { return }

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -21,6 +21,13 @@ class SettingsViewController: UIViewController {
         let cell: SettingsTableViewCell
         let handler: (() -> Void)?
     }
+    
+    private lazy var transparentNavigationBarAppearance: UINavigationBarAppearance = {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = .clear
+        appearance.configureWithTransparentBackground()
+        return appearance
+    }()
 
     // MARK: - Subviews
 
@@ -112,7 +119,9 @@ class SettingsViewController: UIViewController {
     }
 
     private func configureFont() {
-        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
+        self.transparentNavigationBarAppearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
+        self.navigationController?.navigationBar.standardAppearance = self.transparentNavigationBarAppearance
+        self.navigationController?.navigationBar.scrollEdgeAppearance = self.transparentNavigationBarAppearance
 
         self.settingsSections.enumerated().forEach { index, section in
             guard let header = self.tableView.headerView(forSection: index) as? SettingsTableViewHeader else { return }

--- a/Doolda/Doolda/Support/Extensions/UIColor+Extensions.swift
+++ b/Doolda/Doolda/Support/Extensions/UIColor+Extensions.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIColor {
     static let dooldaLabel = UIColor(named: "dooldaLabel")
-    static let dooldaSubLabel = UIColor(named: "dooldaSubLabel")
+    static let dooldaSublabel = UIColor(named: "dooldaSublabel")
     static let dooldaBackground = UIColor(named: "dooldaBackground")
     static let dooldaPlaceholder = UIColor(named: "dooldaPlaceholder")
     static let dooldaHighlighted = UIColor(named: "dooldaHighlighted")


### PR DESCRIPTION
## 이슈 목록
- [x] dooldaSublabel 색상이 누락된 문제 해결. (asset name에 오탈자가 있었음)
- [x] 네비게이션 바 타이틀이 초기에 설정안되던 문제 해결. (appearance를 설정하면, navigation bar에 폰트 설정해줘도 먹히지 않음. appearance에 지정해줘야함.)

## 특이사항
* 커신과의 싸움.. 힘들었다


## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

