### PR TITLE
CoreData Context를 계속 생성해 발생하는 오류 수정

### DIFF
--- a/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
@@ -18,7 +18,7 @@ class DiaryViewCoordinator: DiaryViewCoordinatorProtocol {
     
     func start() {
         let urlSessionNetworkService = URLSessionNetworkService()
-        let coreDataPersistenceService = CoreDataPersistenceService()
+        let coreDataPersistenceService = CoreDataPersistenceService.shared
         let coreDataPageEntityPersistenceService = CoreDataPageEntityPersistenceService(coreDataPersistenceService: coreDataPersistenceService)
         let fileManagerPersistenceService = FileManagerPersistenceService()
         

--- a/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
@@ -25,7 +25,7 @@ class EditPageViewCoordinator: EditPageViewCoordinatorProtocol {
         DispatchQueue.main.async {
             let fileManagerPersistenceService = FileManagerPersistenceService()
             let urlSessionNetworkService = URLSessionNetworkService()
-            let coreDataPersistenceService = CoreDataPersistenceService()
+            let coreDataPersistenceService = CoreDataPersistenceService.shared
             let coreDataPageEntityPersistenceService = CoreDataPageEntityPersistenceService(
                 coreDataPersistenceService: coreDataPersistenceService
             )

--- a/Doolda/Doolda/PageDetailScene/PageDetailViewCoordinator.swift
+++ b/Doolda/Doolda/PageDetailScene/PageDetailViewCoordinator.swift
@@ -20,7 +20,7 @@ class PageDetailViewCoordinator: PageDetailViewCoordinatorProtocol {
 
     func start() {
         let networkService = URLSessionNetworkService()
-        let coreDataPersistenceService = CoreDataPersistenceService()
+        let coreDataPersistenceService = CoreDataPersistenceService.shared
         let coreDataPageEntityPersistenceService = CoreDataPageEntityPersistenceService(coreDataPersistenceService: coreDataPersistenceService)
         let fileManagerPersistenceService = FileManagerPersistenceService()
 

--- a/Doolda/Doolda/Service/CoreData/CoreDataPageEntityPersistenceService.swift
+++ b/Doolda/Doolda/Service/CoreData/CoreDataPageEntityPersistenceService.swift
@@ -93,9 +93,11 @@ class CoreDataPageEntityPersistenceService: CoreDataPageEntityPersistenceService
                     )
                     let fetchResult = try context.fetch(fetchRequest)
                     
-                    if let cachedCoreDataPage = fetchResult.first {
+                    if let cachedCoreDataPage = fetchResult.first,
+                       cachedCoreDataPage.updatedTime != pageEntity.updatedTime {
                         cachedCoreDataPage.update(pageEntity)
-                    } else if let coreDataPage = NSManagedObject(entity: coreDataPageEntity, insertInto: context) as? CoreDataPageEntity {
+                    } else if fetchResult.isEmpty,
+                              let coreDataPage = NSManagedObject(entity: coreDataPageEntity, insertInto: context) as? CoreDataPageEntity {
                         coreDataPage.update(pageEntity)
                     }
                     

--- a/Doolda/Doolda/Service/CoreData/CoreDataPersistenceService.swift
+++ b/Doolda/Doolda/Service/CoreData/CoreDataPersistenceService.swift
@@ -26,29 +26,30 @@ enum CoreDataPersistenceServiceError: LocalizedError {
 final class CoreDataPersistenceService: CoreDataPersistenceServiceProtocol {
     static let coreDataModelName = "CoreDataModel"
     
-    private var isPersistentStoreLoaded = false
+    static let shared = CoreDataPersistenceService()
     
-    private let persistentContainer: NSPersistentContainer
-    
-    init() {
-        self.persistentContainer = NSPersistentContainer(name: Self.coreDataModelName)
-        self.persistentContainer.loadPersistentStores { _, error in
-            guard error == nil else { return }
-            self.isPersistentStoreLoaded = true
-        }
-    }
-    
-    var context: NSManagedObjectContext? {
+    lazy var context: NSManagedObjectContext? = {
         guard self.isPersistentStoreLoaded else { return nil }
         let context = self.persistentContainer.viewContext
         context.automaticallyMergesChangesFromParent = true
         return context
-    }
+    }()
     
-    var backgroundContext: NSManagedObjectContext? {
+    lazy var backgroundContext: NSManagedObjectContext? = {
         guard self.isPersistentStoreLoaded else { return nil }
         let context = self.persistentContainer.newBackgroundContext()
         context.automaticallyMergesChangesFromParent = true
         return context
+    }()
+    
+    private var isPersistentStoreLoaded = false
+    private var persistentContainer: NSPersistentContainer
+    
+    private init() {
+        self.persistentContainer = NSPersistentContainer(name: Self.coreDataModelName)
+        self.persistentContainer.loadPersistentStores { [weak self] _, error in
+            guard error == nil else { return }
+            self?.isPersistentStoreLoaded = true
+        }
     }
 }


### PR DESCRIPTION
## 이슈 목록
- [ ] #432 

## 특이사항
* BackgroundContext를 접근시 매번 새로운 인스턴스를 생성하고 있어 앱이 비정상 종료된것으로 보입니다.
* CoreDataPersistenceService를 singleton으로 수정하고 앱 내에서 컨텍스트를 한번만 생성하도록해 이를 방지했습니다.
* 페이지를 CoreData에 저장할 때 수정일이 다른 경우만 저장하도록 했습니다. 

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

