### PR TITLE
스티커가 팩에서 튕겨 나가는 현상을 수정

### DIFF
--- a/Doolda/Doolda/EditPageScene/StickerPickerScene/PackedStickerCollectionViewCell.swift
+++ b/Doolda/Doolda/EditPageScene/StickerPickerScene/PackedStickerCollectionViewCell.swift
@@ -157,7 +157,7 @@ class PackedStickerCollectionViewCell: UICollectionViewCell {
         var widthOffset: CGFloat = 10
         var heightOffset: CGFloat = 10
         var maxHeight: CGFloat = 0
-        let bodyWidth = self.contentView.frame.width - 16
+        let bodyWidth = self.frame.width - 16
 
         for sticker in stickerPack.stickersName {
             guard let stickerImage = UIImage(named: sticker) else { continue }
@@ -235,7 +235,7 @@ class PackedStickerCollectionViewCell: UICollectionViewCell {
         let stickerView = UIImageView(image: stickerImage)
         stickerView.contentMode = .scaleAspectFit
 
-        let bodyWidth = self.contentView.frame.width - 16
+        let bodyWidth = self.frame.width - 16
         let width: CGFloat
         let height: CGFloat
         let imageRatio = stickerImage.size.width / stickerImage.size.height

--- a/Doolda/Doolda/EditPageScene/StickerPickerScene/PackedStickerCollectionViewCell.swift
+++ b/Doolda/Doolda/EditPageScene/StickerPickerScene/PackedStickerCollectionViewCell.swift
@@ -154,12 +154,22 @@ class PackedStickerCollectionViewCell: UICollectionViewCell {
     // MARK: - Public Methods
 
     func configure(with stickerPack: StickerPackEntity) {
-        var widthOffset: CGFloat = 20
-        var heightOffset: CGFloat = 20
+        var widthOffset: CGFloat = 10
+        var heightOffset: CGFloat = 10
+        var maxHeight: CGFloat = 0
+        let bodyWidth = self.contentView.frame.width - 16
 
         for sticker in stickerPack.stickersName {
             guard let stickerImage = UIImage(named: sticker) else { continue }
             let stickerView = self.configureStickerView(with: stickerImage)
+            let stickerWidth = stickerView.frame.width
+            maxHeight = max(stickerView.frame.height, maxHeight)
+
+            if widthOffset + stickerWidth >= bodyWidth {
+                widthOffset = 10
+                heightOffset += maxHeight + 5
+                maxHeight = 0
+            }
 
             self.stickerPackBody.addSubview(stickerView)
             stickerView.frame.origin = CGPoint(x: widthOffset, y: heightOffset)
@@ -168,12 +178,7 @@ class PackedStickerCollectionViewCell: UICollectionViewCell {
             self.addCollider(to: stickerView)
             self.itemBehavior.addItem(stickerView)
 
-            if widthOffset < 100 {
-                widthOffset += 30
-            } else {
-                widthOffset = 20
-                heightOffset += 50
-            }
+            widthOffset += stickerWidth + 5
         }
 
         let coverStickerImage = UIImage(named: stickerPack.coverStickerName)
@@ -230,15 +235,16 @@ class PackedStickerCollectionViewCell: UICollectionViewCell {
         let stickerView = UIImageView(image: stickerImage)
         stickerView.contentMode = .scaleAspectFit
 
+        let bodyWidth = self.contentView.frame.width - 16
         let width: CGFloat
         let height: CGFloat
         let imageRatio = stickerImage.size.width / stickerImage.size.height
 
         if stickerImage.size.width > stickerImage.size.height {
-            width = self.frame.width / CGFloat(self.maximumCollisionCount - 1)
+            width = bodyWidth / CGFloat(self.maximumCollisionCount - 1)
             height = width / imageRatio
         } else {
-            height = self.frame.width / CGFloat(self.maximumCollisionCount - 1)
+            height = bodyWidth / CGFloat(self.maximumCollisionCount - 1)
             width = height * imageRatio
         }
         stickerView.frame.size = CGSize(width: width, height: height)


### PR DESCRIPTION

## 특이사항
* 뷰 크기를 이용해 스티커가 정확히 팩 안으로 들어오도록 origin 조정해서 해결했습니다


## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

