### PR TITLE
혼자 쓰기 모드에서 친구 끊기 시 발생하는 오류사항 수정

### DIFF
--- a/Doolda/Doolda/Data/Repositories/PairRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PairRepository.swift
@@ -77,4 +77,18 @@ final class PairRepository: PairRepositoryProtocol {
         }
         .eraseToAnyPublisher()
     }
+    
+    func deletePair(with user: User) -> AnyPublisher<User, Error> {
+        guard let pairId = user.pairId else {
+            return Fail(error: PairRepositoryError.nilUserPairId).eraseToAnyPublisher()
+        }
+        
+        let publisher: AnyPublisher<[String: Any], Error> = self.urlSessionNetworkService
+            .request(FirebaseAPIs.deletePairDocument(pairId.ddidString))
+        
+        return publisher.map { _ in
+            return User(id: user.id, pairId: nil, friendId: nil)
+        }
+        .eraseToAnyPublisher()
+    }
 }

--- a/Doolda/Doolda/Data/Repositories/PairRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PairRepository.swift
@@ -34,8 +34,10 @@ final class PairRepository: PairRepositoryProtocol {
         guard let pairId = user.pairId else {
             return Fail(error: PairRepositoryError.nilUserPairId).eraseToAnyPublisher()
         }
-        let publisher: AnyPublisher<PairDocument, Error> = self.urlSessionNetworkService
-            .request(FirebaseAPIs.createPairDocument(pairId.ddidString, user.id.ddidString))
+        
+        let request = FirebaseAPIs.createPairDocument(pairId.ddidString, user.id.ddidString)
+        let publisher: AnyPublisher<PairDocument, Error> = self.urlSessionNetworkService.request(request)
+        
         return publisher.tryMap { pairDocument in
             guard let pairIdString = pairDocument.pairId,
                   let pairId = DDID(from: pairIdString) else {
@@ -50,8 +52,10 @@ final class PairRepository: PairRepositoryProtocol {
         guard let pairId = user.pairId else {
             return Fail(error: PairRepositoryError.nilUserPairId).eraseToAnyPublisher()
         }
-        let publisher: AnyPublisher<PairDocument, Error> = self.urlSessionNetworkService
-            .request(FirebaseAPIs.patchPairDocument(pairId.ddidString, user.id.ddidString))
+        
+        let request = FirebaseAPIs.patchPairDocument(pairId.ddidString, user.id.ddidString)
+        let publisher: AnyPublisher<PairDocument, Error> = self.urlSessionNetworkService.request(request)
+        
         return publisher.tryMap { pairDocument in
             guard let pairIdString = pairDocument.pairId,
                   let pairId = DDID(from: pairIdString) else {
@@ -66,8 +70,10 @@ final class PairRepository: PairRepositoryProtocol {
         guard let pairId = user.pairId else {
             return Fail(error: PairRepositoryError.nilUserPairId).eraseToAnyPublisher()
         }
-        let publisher: AnyPublisher<PairDocument, Error> = self.urlSessionNetworkService
-            .request(FirebaseAPIs.getPairDocument(pairId.ddidString))
+        
+        let request = FirebaseAPIs.getPairDocument(pairId.ddidString)
+        let publisher: AnyPublisher<PairDocument, Error> = self.urlSessionNetworkService.request(request)
+        
         return publisher.tryMap { pairDocument in
             guard let recentlyEditedUserIdString = pairDocument.recentlyEditedUser,
                   let recentlyEditedUser = DDID(from: recentlyEditedUserIdString) else {
@@ -83,8 +89,8 @@ final class PairRepository: PairRepositoryProtocol {
             return Fail(error: PairRepositoryError.nilUserPairId).eraseToAnyPublisher()
         }
         
-        let publisher: AnyPublisher<[String: Any], Error> = self.urlSessionNetworkService
-            .request(FirebaseAPIs.deletePairDocument(pairId.ddidString))
+        let request = FirebaseAPIs.deletePairDocument(pairId.ddidString)
+        let publisher: AnyPublisher<[String: Any], Error> = self.urlSessionNetworkService.request(request)
         
         return publisher.map { _ in
             return User(id: user.id, pairId: nil, friendId: nil)

--- a/Doolda/Doolda/Domain/Interfaces/PairRepositoryProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/PairRepositoryProtocol.swift
@@ -10,7 +10,6 @@ import Foundation
 
 protocol PairRepositoryProtocol {
     func setPairId(with user: User) -> AnyPublisher<DDID, Error>
-    
     func setRecentlyEditedUser(with user: User) -> AnyPublisher<DDID, Error>
     func fetchRecentlyEditedUser(with user: User) -> AnyPublisher<DDID, Error>
     func deletePair(with user: User) -> AnyPublisher<User, Error>

--- a/Doolda/Doolda/Domain/Interfaces/PairRepositoryProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/PairRepositoryProtocol.swift
@@ -13,4 +13,5 @@ protocol PairRepositoryProtocol {
     
     func setRecentlyEditedUser(with user: User) -> AnyPublisher<DDID, Error>
     func fetchRecentlyEditedUser(with user: User) -> AnyPublisher<DDID, Error>
+    func deletePair(with user: User) -> AnyPublisher<User, Error>
 }

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -139,7 +139,7 @@ class SettingsViewController: UIViewController {
     private func bindUI() {
         self.viewModel.pushNotificationStatePublisher
             .receive(on: DispatchQueue.main)
-            .sink{ [weak self] isPushNotificationOn in
+            .sink { [weak self] isPushNotificationOn in
                 guard let isPushNotificationOn = isPushNotificationOn,
                       let section = self?.settingsSections[exist: 0],
                       let alertCell = section.settingsOptions[exist: 0]?.cell else { return }

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -156,6 +156,15 @@ class SettingsViewController: UIViewController {
             }
             .store(in: &self.cancellables)
 
+        self.viewModel.errorPublisher
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] error in
+                let alert = UIAlertController.defaultAlert(title: "알림", message: error.localizedDescription) { _ in }
+                self?.present(alert, animated: true, completion: nil)
+            }
+            .store(in: &self.cancellables)
+
         self.disconnectButton.publisher(for: .touchUpInside)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -157,10 +157,10 @@ class SettingsViewController: UIViewController {
             .store(in: &self.cancellables)
 
         self.viewModel.errorPublisher
-            .compactMap { $0 }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
-                let alert = UIAlertController.defaultAlert(title: "알림", message: error.localizedDescription) { _ in }
+                guard let error = error as? LocalizedError else { return }
+                let alert = UIAlertController.defaultAlert(title: "오류", message: error.localizedDescription) { _ in }
                 self?.present(alert, animated: true, completion: nil)
             }
             .store(in: &self.cancellables)

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -106,9 +106,10 @@ class SettingsViewModel: SettingsViewModelProtocol {
                 guard case .failure(let error) = completion else { return }
                 self?.error = error
             } receiveValue: { [weak self] _ in
-                guard let friendId = self?.user.friendId,
-                      self?.user.id != friendId else { return }
-                self?.firebaseMessageUseCase.sendMessage(to: friendId, message: PushMessageEntity.userDisconnected)
+                if let friendId = self?.user.friendId,
+                   friendId != self?.user.id {
+                    self?.firebaseMessageUseCase.sendMessage(to: friendId, message: PushMessageEntity.userDisconnected)
+                }
                 self?.coordinator.splashViewRequested()
             }
             .store(in: &self.cancellables)

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -20,6 +20,7 @@ protocol SettingsViewModelInput {
 }
 
 protocol SettingsViewModelOutput {
+    var errorPublisher: Published<Error?>.Publisher { get }
     var pushNotificationStatePublisher: Published<Bool?>.Publisher { get }
     var selectedFontPublisher: Published<FontType?>.Publisher { get }
 }
@@ -27,6 +28,7 @@ protocol SettingsViewModelOutput {
 typealias SettingsViewModelProtocol = SettingsViewModelInput & SettingsViewModelOutput
 
 class SettingsViewModel: SettingsViewModelProtocol {
+    var errorPublisher: Published<Error?>.Publisher { self.$error }
     var pushNotificationStatePublisher: Published<Bool?>.Publisher { self.$isPushNotificationOn }
     var selectedFontPublisher: Published<FontType?>.Publisher { self.$selectedFont }
 
@@ -38,6 +40,7 @@ class SettingsViewModel: SettingsViewModelProtocol {
     private let firebaseMessageUseCase: FirebaseMessageUseCaseProtocol
     
     private var cancellables: Set<AnyCancellable> = []
+    @Published private var error: Error?
     @Published private var isPushNotificationOn: Bool?
     @Published private var selectedFont: FontType?
 
@@ -101,7 +104,7 @@ class SettingsViewModel: SettingsViewModelProtocol {
         self.pairUserUseCase.disconnectPair(user: self.user)
             .sink { [weak self] completion in
                 guard case .failure(let error) = completion else { return }
-                print(error)
+                self?.error = error
             } receiveValue: { [weak self] _ in
                 guard let friendId = self?.user.friendId,
                       self?.user.id != friendId else { return }

--- a/Doolda/Doolda/Support/Constants/API.swift
+++ b/Doolda/Doolda/Support/Constants/API.swift
@@ -15,6 +15,7 @@ enum FirebaseAPIs: URLRequestBuilder {
     case getPairDocument(String)
     case createPairDocument(String, String)
     case patchPairDocument(String, String)
+    case deletePairDocument(String)
     
     case getPageDocuments(String, Date?)
     case createPageDocument(String, Date, Date, String, String)
@@ -49,7 +50,7 @@ extension FirebaseAPIs {
             return "documents/user/\(userId)"
         case .createUserDocument:
             return "documents/user"
-        case .getPairDocument(let pairId), .patchPairDocument(let pairId, _):
+        case .getPairDocument(let pairId), .patchPairDocument(let pairId, _), .deletePairDocument(let pairId):
             return "documents/pair/\(pairId)"
         case .createPairDocument:
             return "documents/pair"
@@ -69,7 +70,13 @@ extension FirebaseAPIs {
 extension FirebaseAPIs {
     var parameters: [String : String]? {
         switch self {
-        case .getUserDocuement, .getPairDocument, .getPageDocuments, .sendFirebaseMessage, .getFCMTokenDocument, .patchFCMTokenDocument:
+        case .getUserDocuement,
+             .getPairDocument,
+             .getPageDocuments,
+             .sendFirebaseMessage,
+             .getFCMTokenDocument,
+             .patchFCMTokenDocument,
+             .deletePairDocument:
             return nil
         case .createUserDocument(let id), .createPairDocument(let id, _):
             return ["documentId": id]
@@ -92,6 +99,8 @@ extension FirebaseAPIs {
             return .post
         case .patchUserDocument, .patchPairDocument, .patchPageDocument, .patchFCMTokenDocument:
             return .patch
+        case .deletePairDocument:
+            return .delete
         }
     }
 }
@@ -112,7 +121,7 @@ extension FirebaseAPIs {
 extension FirebaseAPIs {
     var body: [String: Any]? {
         switch self {
-        case .getUserDocuement, .getPairDocument, .getFCMTokenDocument, .uploadDataFile, .downloadDataFile:
+        case .getUserDocuement, .getPairDocument, .getFCMTokenDocument, .uploadDataFile, .downloadDataFile, .deletePairDocument:
             return nil
         case .getPageDocuments(let pairId, let date):
             var filters = [[String: Any]]()


### PR DESCRIPTION
## 이슈 목록
- [ ] #435

## 특이사항
### 혼자쓰기 모드 친구 끊기 시 화면 전환이 진행되지 않던 문제
* 혼자 쓰기 유저가 친구 끊기시 친구 연결 화면으로 넘어가지 않는 현상은 친구가 있을때만 화면 전환을 넣어서 이동되지 않고 있던거였습니다.
* 혼자 쓰기 유저도 친구 끊기시 친구 연결 화면으로 전환되도록 수정했습니다.

### 혼자 쓰기 모드에서 친구 끊기 후 다시 혼자 쓰기 모드 사용이 안되는 문제
* 친구 끊기 과정에 Firebase의 Pair Document를 제거하지 않아 다시 혼자 쓰기 사용시 중복된 PairId의 Document를 생성할 수 없어 에러가 발생했습니다.
* 친구 끊기 과정에 Pair Document를 제거해 혼자 쓰기 유저가 계속 혼자 쓰기 모드를 사용해도 에러가 발생하지 않도록 수정했습니다.

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

