### PR TITLE
전체적인 버튼 크기 및 햅틱 반응 수정

### DIFF
--- a/Doolda/Doolda/Common/DooldaButton.swift
+++ b/Doolda/Doolda/Common/DooldaButton.swift
@@ -5,15 +5,52 @@
 //  Created by Seunghun Yang on 2021/11/21.
 //
 
+import Combine
 import UIKit
 
 class DooldaButton: UIButton {
+
+    // Private Properties
+
+    private var cancellables: Set<AnyCancellable> = []
+    private lazy var hapticGenerator: UIImpactFeedbackGenerator = {
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        return generator
+    }()
+
+    // Override Properties
+
     override var isEnabled: Bool {
         didSet { self.alpha = self.isEnabled ? 1.0 : 0.5 }
     }
-    
+
+    // Initializers
+
+    init() {
+        super.init(frame: .zero)
+        self.bindUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.bindUI()
+    }
+
+    // LifeCycle Methods
+
     override func layoutSubviews() {
         super.layoutSubviews()
         self.layer.cornerRadius = self.frame.height / 2
+    }
+
+    // Private Methods
+
+    private func bindUI() {
+        self.publisher(for: .touchUpInside)
+            .sink { [weak self] _ in
+                self?.hapticGenerator.prepare()
+                self?.hapticGenerator.impactOccurred()
+            }
+            .store(in: &self.cancellables)
     }
 }

--- a/Doolda/Doolda/DiaryScene/DiaryCollectionViewHeader.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryCollectionViewHeader.swift
@@ -73,7 +73,7 @@ class DiaryCollectionViewHeader: UICollectionReusableView {
     }()
     
     private lazy var hapticGenerator: UIImpactFeedbackGenerator = {
-        let generator = UIImpactFeedbackGenerator(style: .heavy)
+        let generator = UIImpactFeedbackGenerator(style: .light)
         return generator
     }()
     

--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -200,12 +200,16 @@ class DiaryViewController: UIViewController {
         
         self.filterButton.publisher(for: .touchUpInside)
             .sink { [weak self] _ in
+                self?.hapticGenerator.prepare()
+                self?.hapticGenerator.impactOccurred()
                 self?.viewModel.filterButtonDidTap()
             }
             .store(in: &self.cancellables)
         
         self.settingsButton.publisher(for: .touchUpInside)
             .sink { [weak self] _ in
+                self?.hapticGenerator.prepare()
+                self?.hapticGenerator.impactOccurred()
                 self?.viewModel.settingsButtonDidTap()
             }
             .store(in: &self.cancellables)

--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -81,7 +81,7 @@ class DiaryViewController: UIViewController {
     }()
     
     private lazy var hapticGenerator: UIImpactFeedbackGenerator = {
-        let generator = UIImpactFeedbackGenerator(style: .heavy)
+        let generator = UIImpactFeedbackGenerator(style: .light)
         return generator
     }()
     

--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -62,18 +62,21 @@ class DiaryViewController: UIViewController {
     private lazy var displayModeToggleButton: UIButton = {
         let button = UIButton()
         button.setImage(.square, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     
     private lazy var filterButton: UIButton = {
         let button = UIButton()
         button.setImage(.line3HorizontalDecrease, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     
     private lazy var settingsButton: UIButton = {
         let button = UIButton()
         button.setImage(.gearshape, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     
@@ -132,6 +135,7 @@ class DiaryViewController: UIViewController {
         self.navigationController?.navigationBar.isHidden = false
         self.navigationController?.navigationBar.barTintColor = .dooldaBackground
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.settingsButton)
+
         self.navigationItem.leftBarButtonItems = [
             UIBarButtonItem(customView: self.displayModeToggleButton),
             UIBarButtonItem(customView: self.filterButton)

--- a/Doolda/Doolda/DiaryScene/FilterOptionScene/FilterOptionBottomSheetViewController.swift
+++ b/Doolda/Doolda/DiaryScene/FilterOptionScene/FilterOptionBottomSheetViewController.swift
@@ -54,6 +54,11 @@ class FilterOptionBottomSheetViewController: BottomSheetViewController {
         button.layer.cornerRadius = 22
         return button
     }()
+
+    private lazy var hapticGenerator: UIImpactFeedbackGenerator = {
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        return generator
+    }()
     
     // MARK: - Private Properties
     
@@ -171,6 +176,8 @@ class FilterOptionBottomSheetViewController: BottomSheetViewController {
         )
             .sink { [weak self] _, authorFilter, orderFilter in
                 guard let self = self else { return }
+                self.hapticGenerator.prepare()
+                self.hapticGenerator.impactOccurred()
                 self.delegate?.applyButtonDidTap(self, authorFilter: authorFilter, orderFilter: orderFilter)
                 self.dismiss(animated: true)
             }

--- a/Doolda/Doolda/EditPageScene/EditPageViewController.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewController.swift
@@ -47,24 +47,28 @@ class EditPageViewController: UIViewController {
     private lazy var addPhotoComponentButton: UIButton = {
         var button = UIButton(frame: CGRect(x: .zero, y: .zero, width: 24, height: 24))
         button.setImage(.photo, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     
     private lazy var addTextComponentButton: UIButton = {
         var button = UIButton(frame: CGRect(x: .zero, y: .zero, width: 24, height: 24))
         button.setImage(.textformat, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     
     private lazy var addStickerComponentButton: UIButton = {
         var button = UIButton(frame: CGRect(x: .zero, y: .zero, width: 24, height: 24))
         button.setImage(.sticker, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     
     private lazy var changeBackgroundTypeButton: UIButton = {
         var button = UIButton(frame: CGRect(x: .zero, y: .zero, width: 24, height: 24))
         button.setImage(.background, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     
@@ -198,7 +202,7 @@ class EditPageViewController: UIViewController {
             make.leading.equalTo(self.pageView)
             make.top.equalTo(self.pageView.snp.bottom).offset(5)
             make.bottom.equalToSuperview().offset(-5)
-            make.width.equalTo(135)
+            make.width.equalTo(150)
         }
         
         self.view.addSubview(self.activityIndicator)

--- a/Doolda/Doolda/EditPageScene/EditPageViewController.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewController.swift
@@ -21,12 +21,14 @@ class EditPageViewController: UIViewController {
     private lazy var cancelButton: UIButton = {
         var button = UIButton()
         button.setImage(.xmark, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     
     private lazy var saveButton: UIButton = {
         var button = UIButton()
         button.setImage(.checkmark, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     

--- a/Doolda/Doolda/EditPageScene/EditPageViewController.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewController.swift
@@ -219,6 +219,8 @@ class EditPageViewController: UIViewController {
         self.cancelButton.publisher(for: .touchUpInside)
             .sink { [weak self] _ in
                 guard let self = self else { return }
+                self.hapticGenerator.prepare()
+                self.hapticGenerator.impactOccurred()
                 let alert = UIAlertController.selectAlert(
                     title: "편집 나가기",
                     message: "페이지를 저장하지 않고 나갈 시, 작성한 내용은 저장되지 않습니다.",
@@ -233,6 +235,8 @@ class EditPageViewController: UIViewController {
         self.saveButton.publisher(for: .touchUpInside)
             .sink { [weak self] _ in
                 guard let self = self else { return }
+                self.hapticGenerator.prepare()
+                self.hapticGenerator.impactOccurred()
                 let alert = UIAlertController.selectAlert(
                     title: "편집 저장하기",
                     message: "페이지를 저장하시겠습니까?, 저장 후 더 이상 편집할 수 없습니다.",
@@ -279,24 +283,32 @@ class EditPageViewController: UIViewController {
         self.addPhotoComponentButton.publisher(for: .touchUpInside)
             .sink { [weak self] _ in
                 guard let self = self else { return }
+                self.hapticGenerator.prepare()
+                self.hapticGenerator.impactOccurred()
                 self.viewModel?.photoComponentAddButtonDidTap()
             }.store(in: &self.cancellables)
         
         self.addTextComponentButton.publisher(for: .touchUpInside)
             .sink { [weak self] _ in
                 guard let self = self else { return }
+                self.hapticGenerator.prepare()
+                self.hapticGenerator.impactOccurred()
                 self.viewModel?.textComponentAddButtonDidTap()
             }.store(in: &self.cancellables)
         
         self.addStickerComponentButton.publisher(for: .touchUpInside)
             .sink { [weak self] _ in
                 guard let self = self else { return }
+                self.hapticGenerator.prepare()
+                self.hapticGenerator.impactOccurred()
                 self.viewModel?.stickerComponentAddButtonDidTap()
             }.store(in: &self.cancellables)
         
         self.changeBackgroundTypeButton.publisher(for: .touchUpInside)
             .sink { [weak self] _ in
                 guard let self = self else { return }
+                self.hapticGenerator.prepare()
+                self.hapticGenerator.impactOccurred()
                 self.viewModel?.backgroundTypeButtonDidTap()
             }.store(in: &self.cancellables)
         

--- a/Doolda/Doolda/EditPageScene/EditPageViewController.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewController.swift
@@ -93,7 +93,7 @@ class EditPageViewController: UIViewController {
     }()
     
     private lazy var hapticGenerator: UIImpactFeedbackGenerator = {
-        let generator = UIImpactFeedbackGenerator(style: .heavy)
+        let generator = UIImpactFeedbackGenerator(style: .light)
         return generator
     }()
     

--- a/Doolda/Doolda/EditPageScene/TextEditScene/TextEditViewController.swift
+++ b/Doolda/Doolda/EditPageScene/TextEditScene/TextEditViewController.swift
@@ -124,7 +124,7 @@ class TextEditViewController: UIViewController {
     }
     
     private func configureGenerator() {
-        self.feedbackGenerator = UIImpactFeedbackGenerator(style: .heavy)
+        self.feedbackGenerator = UIImpactFeedbackGenerator(style: .light)
         self.feedbackGenerator?.prepare()
     }
     

--- a/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
+++ b/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
@@ -37,6 +37,11 @@ class PageDetailViewController: UIViewController {
         return activityIndicator
     }()
 
+    private lazy var hapticGenerator: UIImpactFeedbackGenerator = {
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        return generator
+    }()
+
     // MARK: - Override Properties
 
     override var prefersStatusBarHidden: Bool { return true }
@@ -138,6 +143,8 @@ class PageDetailViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self = self else { return }
+                self.hapticGenerator.prepare()
+                self.hapticGenerator.impactOccurred()
                 self.savePageAndShare()
             }
             .store(in: &self.cancellables)
@@ -145,6 +152,8 @@ class PageDetailViewController: UIViewController {
         self.editPageButton.publisher(for: .touchUpInside)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
+                self?.hapticGenerator.prepare()
+                self?.hapticGenerator.impactOccurred()
                 self?.viewModel.editPageButtonDidTap()
             }
             .store(in: &self.cancellables)

--- a/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
+++ b/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
@@ -22,12 +22,14 @@ class PageDetailViewController: UIViewController {
     private lazy var shareButton: UIButton = {
         var button = UIButton(frame: CGRect(x: .zero, y: .zero, width: 24, height: 24))
         button.setImage(.squareAndArrowUp, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     
     private lazy var editPageButton: UIButton = {
         var button = UIButton(frame: CGRect(x: .zero, y: .zero, width: 24, height: 24))
         button.setImage(.squareAndPencil, for: .normal)
+        button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration.init(pointSize: 21), forImageIn: .normal)
         return button
     }()
     

--- a/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
+++ b/Doolda/Doolda/PageDetailScene/PageDetailViewController.swift
@@ -36,6 +36,10 @@ class PageDetailViewController: UIViewController {
         activityIndicator.style = .large
         return activityIndicator
     }()
+
+    // MARK: - Override Properties
+
+    override var prefersStatusBarHidden: Bool { return true }
     
     // MARK: - Private Properties
 

--- a/Doolda/Doolda/PairingScene/PairingViewController.swift
+++ b/Doolda/Doolda/PairingScene/PairingViewController.swift
@@ -106,7 +106,7 @@ class PairingViewController: UIViewController {
     }()
     
     private lazy var hapticGenerator: UIImpactFeedbackGenerator = {
-        let generator = UIImpactFeedbackGenerator(style: .heavy)
+        let generator = UIImpactFeedbackGenerator(style: .light)
         return generator
     }()
     

--- a/Doolda/Doolda/SettingsScene/SettingsDetailedInfoViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsDetailedInfoViewController.swift
@@ -23,6 +23,10 @@ class SettingsDetailedInfoViewController: UIViewController {
         return textView
     }()
 
+    // MARK: - Override Properties
+
+    override var prefersStatusBarHidden: Bool { return true }
+
     // MARK: - Public Properties
 
     @Published var titleText: String?


### PR DESCRIPTION
## 이슈 목록
- [x] #445

## 특이사항
* 다이어리 화면의 상단 버튼, 다이어리 상세 화면의 하단 버튼, 페이지 편집 화면의 상단/하단 버튼 크기를 조금씩 키웠습니다. **크기가 적당한지 꼭!!!! 확인 부탁드립니다!!!**
* 모든 버튼에 햅틱 반응을 추가했고, 햅틱 강도를 light로 통일했습니다.
* 둘다 버튼에 햅틱 반응을 추가했습니다.
* 일부 화면에서 status bar가 살아있길래 쳐 냈습니다 (다이어리 상세화면, 설정 상세화면)

## 실행 화면

| 수정 전: 다이어리 화면 | 수정 후: 다이어리 화면 |
| :--: | :--: |
| ![IMG_3511](https://user-images.githubusercontent.com/61934702/143845782-b21d52d3-63c7-4c64-b7f7-6c73ccdfafd7.PNG) | ![IMG_3516](https://user-images.githubusercontent.com/61934702/143845880-b17c519e-6fc7-4363-a0c8-76f42f05e024.PNG) | 

| 수정 전: 다이어리 상세 화면 | 수정 후: 다이어리 상세 화면 | 
| :--: | :--: |
| ![IMG_3517](https://user-images.githubusercontent.com/61934702/143846765-f551f535-2c27-4a63-a621-8d374e0156ae.PNG) | ![IMG_3515](https://user-images.githubusercontent.com/61934702/143845963-160db95c-e69f-4af1-a147-06d30b70dbeb.PNG) | 

| 수정 전 : 편집 화면 | 수정 후: 편집 화면 |
| :--: | :--: |
| ![Simulator Screen Shot - iPhone 13 - 2021-11-29 at 17 32 50](https://user-images.githubusercontent.com/61934702/143846281-1c5d819e-06b4-4eaa-abfd-40049e777131.png) | ![Simulator Screen Shot - iPhone 13 - 2021-11-29 at 17 42 22](https://user-images.githubusercontent.com/61934702/143846328-b37d74ba-6e20-4d34-b7fd-cc34052bce29.png) |


## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

