### PR TITLE
RawPageRepository의 NetworkService 교체 작업 

### DIFF
--- a/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
@@ -48,7 +48,7 @@ final class DiaryViewCoordinator: BaseCoordinator {
         )
         
         let rawPageRepository = RawPageRepository(
-            networkService: urlSessionNetworkService,
+            networkService: FirebaseNetworkService.shared,
             coreDataPageEntityPersistenceService: coreDataPageEntityPersistenceService,
             fileManagerPersistenceService: fileManagerPersistenceService
         )

--- a/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
@@ -117,7 +117,7 @@ final class EditPageViewCoordinator: BaseCoordinator {
                 pageEntityPersistenceService: coreDataPageEntityPersistenceService
             )
             let rawPageRepository = RawPageRepository(
-                networkService: urlSessionNetworkService,
+                networkService: FirebaseNetworkService.shared,
                 coreDataPageEntityPersistenceService: coreDataPageEntityPersistenceService,
                 fileManagerPersistenceService: fileManagerPersistenceService
             )

--- a/Doolda/Doolda/PageDetailScene/PageDetailViewCoordinator.swift
+++ b/Doolda/Doolda/PageDetailScene/PageDetailViewCoordinator.swift
@@ -56,7 +56,7 @@ final class PageDetailViewCoordinator: BaseCoordinator {
         let fileManagerPersistenceService = FileManagerPersistenceService.shared
 
         let rawPageRepository = RawPageRepository(
-            networkService: networkService,
+            networkService: FirebaseNetworkService.shared,
             coreDataPageEntityPersistenceService: coreDataPageEntityPersistenceService,
             fileManagerPersistenceService: fileManagerPersistenceService
         )


### PR DESCRIPTION
## 이슈 목록
- [x] : #522   

## 특이사항
* `FirebaseNetworkService` 도 다른 Service들과 마찬가지로 싱글턴객체를 만듦.
* 기존 로직이 불필요하게 복잡하게 느껴져서 가독성을 개선하는 과정에서 추가적으로 기존 코드에서부터 있었던 문제를 발견, #523 으로 등록, 개선 예정

## 함께 의논해볼만한 것
`CoreDataPageEntityPersistenceService`, `FileManagerPersistenceService` 같이 동기(맞나?) 인것은 굳이 Combine Publisher를 안쓰는(불필요한 구독을 만들지 않는)쪽으로 가는게 지금의 제 눈에는 더 깔끔해보이는데 다른분들도 동의하시면 작업하면 좋을 것 같습니다.
