### PR TITLE
PageRepository의 NetworkService 교체 작업

### DIFF
--- a/Doolda/Doolda/Data/Interfaces/FirebaseNetworkServiceProtocol.swift
+++ b/Doolda/Doolda/Data/Interfaces/FirebaseNetworkServiceProtocol.swift
@@ -13,6 +13,8 @@ protocol FirebaseNetworkServiceProtocol {
     func setDocument(collection: FirebaseCollection, document: String, dictionary: [String: Any]) -> AnyPublisher<Void, Error>
     func getDocument<T: DataTransferable>(collection: FirebaseCollection, document: String) -> AnyPublisher<T, Error>
     func setDocument<T: DataTransferable>(collection: FirebaseCollection, document: String, transferable: T) -> AnyPublisher<Void, Error>
+    func getDocuments(collection: FirebaseCollection, conditions: [String: Any]?) -> AnyPublisher<[[String: Any]], Error>
+    func getDocuments<T: DataTransferable>(collection: FirebaseCollection, conditions: [String: Any]?) -> AnyPublisher<[T], Error>
     func deleteDocument(collection: FirebaseCollection, document: String) -> AnyPublisher<Void, Error>
     func uploadData(path: String, fileName: String, data: Data) -> AnyPublisher<URL, Error>
     func donwloadData(path: String, fileName: String) -> AnyPublisher<Data, Error>

--- a/Doolda/Doolda/Data/Repositories/PageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PageRepository.swift
@@ -26,19 +26,16 @@ enum PageRepositoryError: LocalizedError {
 }
 
 class PageRepository: PageRepositoryProtocol {
-    private let urlSessionNetworkService: URLSessionNetworkServiceProtocol
     private let pageEntityPersistenceService: CoreDataPageEntityPersistenceServiceProtocol
     private let firebaseNetworkService: FirebaseNetworkServiceProtocol
     
     private var cancellables = Set<AnyCancellable>()
     
     init(
-        urlSessionNetworkService: URLSessionNetworkServiceProtocol,
+        networkService: FirebaseNetworkServiceProtocol,
         pageEntityPersistenceService: CoreDataPageEntityPersistenceServiceProtocol
     ) {
-        // FIXME: - 외부에서 주입하도록 수정
-        self.firebaseNetworkService = FirebaseNetworkService()
-        self.urlSessionNetworkService = urlSessionNetworkService
+        self.firebaseNetworkService = networkService
         self.pageEntityPersistenceService = pageEntityPersistenceService
     }
     
@@ -94,7 +91,10 @@ class PageRepository: PageRepositoryProtocol {
             guard let self = self else { return promise(.failure(PageRepositoryError.failedToFetchPages)) }
             let conditions = ["pairId": pair.ddidString]
             
-            let firebaseNetworkServicePublisher: AnyPublisher<[PageEntity], Error> = self.firebaseNetworkService.getDocuments(collection: .page, conditions: conditions)
+            let firebaseNetworkServicePublisher: AnyPublisher<[PageEntity], Error> = self.firebaseNetworkService.getDocuments(
+                collection: .page,
+                conditions: conditions
+            )
             
             firebaseNetworkServicePublisher.sink { completion in
                 guard case .failure(let error) = completion else { return }

--- a/Doolda/Doolda/Data/Repositories/PageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PageRepository.swift
@@ -120,24 +120,6 @@ class PageRepository: PageRepositoryProtocol {
         .eraseToAnyPublisher()
     }
     
-    private func fetchPageFromServer(pairId: DDID, after: Date?) -> AnyPublisher<[PageEntity], Error> {
-        let request = FirebaseAPIs.getPageDocuments(pairId.ddidString, after)
-        let publisher: AnyPublisher<[[String: Any]], Error> = self.urlSessionNetworkService.request(request)
-        return publisher
-            .map({ dictionaries in
-                var documents: [PageEntity] = []
-                dictionaries.forEach { dictionary in
-                    guard let documentDictionary = dictionary["document"] as? [String: Any],
-                          let fieldsDictionary = documentDictionary["fields"] as? [String: [String: String]],
-                          let pageDocument = PageDocument(document: fieldsDictionary),
-                          let pageEntity = pageDocument.toPageEntity() else { return }
-                    documents.append(pageEntity)
-                }
-                return documents
-            })
-            .eraseToAnyPublisher()
-    }
-    
     private func savePageToCache(pages: [PageEntity]) -> AnyPublisher<Void, Error> {
         let savePublishers = pages.map { self.pageEntityPersistenceService.savePageEntity($0) }
         

--- a/Doolda/Doolda/Data/Repositories/PageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PageRepository.swift
@@ -13,12 +13,14 @@ enum PageRepositoryError: LocalizedError {
     case userNotPaired
     case failedToFetchPages
     case failedToUpdatePage
+    case failedToSavePage
     
     var errorDescription: String? {
         switch self {
         case .userNotPaired: return "페어링 된 유저가 없습니다."
         case .failedToFetchPages: return "페이지 패치에 실패했습니다."
         case .failedToUpdatePage: return "페이지 업데이트에 실패했습니다."
+        case .failedToSavePage: return "페이지 저장에 실패했습니다."
         }
     }
 }

--- a/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
@@ -43,7 +43,7 @@ final class DiaryViewCoordinator: BaseCoordinator {
         
         let pairRepository = PairRepository(networkService: firebaseNetworkService)
         let pageRepository = PageRepository(
-            urlSessionNetworkService: urlSessionNetworkService,
+            networkService: FirebaseNetworkService.shared,
             pageEntityPersistenceService: coreDataPageEntityPersistenceService
         )
         

--- a/Doolda/Doolda/Domain/Entities/PageEntity.swift
+++ b/Doolda/Doolda/Domain/Entities/PageEntity.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+import Firebase
+
 struct PageEntity: Hashable {
     let author: User
     let createdTime: Date
@@ -18,5 +20,32 @@ struct PageEntity: Hashable {
         hasher.combine(createdTime)
         hasher.combine(updatedTime)
         hasher.combine(jsonPath)
+    }
+}
+
+extension PageEntity: DataTransferable {
+    init?(dictionary: [String : Any]) {
+        guard let authorId = dictionary["author"] as? String,
+              let pairId = dictionary["pairId"] as? String,
+              let authorDDID = DDID(from: authorId),
+              let pairDDID = DDID(from: pairId),
+              let createdTime = dictionary["createdTime"] as? Timestamp,
+              let updatedTime = dictionary["updatedTime"] as? Timestamp,
+              let jsonPath = dictionary["jsonPath"] as? String else { return nil }
+        
+        self.author = User(id: authorDDID, pairId: pairDDID)
+        self.createdTime = createdTime.dateValue()
+        self.updatedTime = updatedTime.dateValue()
+        self.jsonPath = jsonPath
+    }
+    
+    var dictionary: [String : Any] {
+        return [
+            "author": self.author.id.ddidString,
+            "createdTime": self.createdTime,
+            "updatedTime": self.updatedTime,
+            "jsonPath": self.jsonPath,
+            "pairId": self.author.pairId?.ddidString ?? ""
+        ]
     }
 }

--- a/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
@@ -113,7 +113,7 @@ final class EditPageViewCoordinator: BaseCoordinator {
                 networkService: urlSessionNetworkService
             )
             let pageRepository = PageRepository(
-                urlSessionNetworkService: urlSessionNetworkService,
+                networkService: FirebaseNetworkService.shared,
                 pageEntityPersistenceService: coreDataPageEntityPersistenceService
             )
             let rawPageRepository = RawPageRepository(


### PR DESCRIPTION
## 이슈 목록
- [ ] #521 

## 특이사항
* PageEntity를 DataTransferable 채택하도록 수정했습니다.
* FirebaseNetworkService에 여러 도큐먼드를 요청하기위한 getDocuments를 추가 구현했습니다.

## 함께 의논해볼 부분
기존 PageRepository에서 PageEntity에 대한 fetch, update 작업 시 PageEntity(MetaData)를 캐싱하도록 구현되어 있습니다. 
Firebase SDK를 활용하게 되면서 Firebase 내부적으로 Offline Data Access를 위해 캐싱 처리를 하는것 같아 보입니다. 
따라서, PageEntity에 대한 추가적인 캐싱이 필요한가 의논해볼 필요가 있는 것 같습니다.

### 참고링크
https://firebase.google.com/docs/firestore/manage-data/enable-offline

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

