### PR TITLE
PairRepository의 NetworkService 교체 작업

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -2957,7 +2957,7 @@
 				CODE_SIGN_ENTITLEMENTS = Doolda/Doolda.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DEVELOPMENT_TEAM = S24Z36WLLR;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Doolda/Resources/Info.plist;
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
@@ -2989,7 +2989,7 @@
 				CODE_SIGN_ENTITLEMENTS = Doolda/Doolda.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B3PWYBKFUK;
+				DEVELOPMENT_TEAM = S24Z36WLLR;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Doolda/Resources/Info.plist;
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";

--- a/Doolda/Doolda/Data/Interfaces/FirebaseNetworkServiceProtocol.swift
+++ b/Doolda/Doolda/Data/Interfaces/FirebaseNetworkServiceProtocol.swift
@@ -13,6 +13,7 @@ protocol FirebaseNetworkServiceProtocol {
     func setDocument(collection: FirebaseCollection, document: String, dictionary: [String: Any]) -> AnyPublisher<Void, Error>
     func getDocument<T: DataTransferable>(collection: FirebaseCollection, document: String) -> AnyPublisher<T, Error>
     func setDocument<T: DataTransferable>(collection: FirebaseCollection, document: String, transferable: T) -> AnyPublisher<Void, Error>
+    func deleteDocument(collection: FirebaseCollection, document: String) -> AnyPublisher<Void, Error>
     func uploadData(path: String, fileName: String, data: Data) -> AnyPublisher<URL, Error>
     func donwloadData(path: String, fileName: String) -> AnyPublisher<Data, Error>
 }

--- a/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
@@ -36,11 +36,12 @@ final class DiaryViewCoordinator: BaseCoordinator {
     
     func start() {
         let urlSessionNetworkService = URLSessionNetworkService.shared
+        let firebaseNetworkService = FirebaseNetworkService.shared
         let coreDataPersistenceService = CoreDataPersistenceService.shared
         let coreDataPageEntityPersistenceService = CoreDataPageEntityPersistenceService(coreDataPersistenceService: coreDataPersistenceService)
         let fileManagerPersistenceService = FileManagerPersistenceService.shared
         
-        let pairRepository = PairRepository(networkService: urlSessionNetworkService)
+        let pairRepository = PairRepository(networkService: firebaseNetworkService)
         let pageRepository = PageRepository(
             urlSessionNetworkService: urlSessionNetworkService,
             pageEntityPersistenceService: coreDataPageEntityPersistenceService

--- a/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
@@ -100,13 +100,14 @@ final class EditPageViewCoordinator: BaseCoordinator {
     func start() {
         DispatchQueue.main.async {
             let fileManagerPersistenceService = FileManagerPersistenceService.shared
+            let firebaseNetworkService = FirebaseNetworkService.shared
             let urlSessionNetworkService = URLSessionNetworkService.shared
             let coreDataPersistenceService = CoreDataPersistenceService.shared
             let coreDataPageEntityPersistenceService = CoreDataPageEntityPersistenceService(
                 coreDataPersistenceService: coreDataPersistenceService
             )
             
-            let pairRepository = PairRepository(networkService: urlSessionNetworkService)
+            let pairRepository = PairRepository(networkService: firebaseNetworkService)
             let imageRepository = ImageRepository(
                 fileManagerService: fileManagerPersistenceService,
                 networkService: urlSessionNetworkService

--- a/Doolda/Doolda/PairingScene/PairingViewCoordinator.swift
+++ b/Doolda/Doolda/PairingScene/PairingViewCoordinator.swift
@@ -33,13 +33,14 @@ class PairingViewCoordinator: BaseCoordinator {
     func start() {
         let userDefaultsPersistenceService = UserDefaultsPersistenceService.shared
         let urlSessionNetworkService = URLSessionNetworkService.shared
+        let firebaseNetworkService = FirebaseNetworkService.shared
         
         let userRepository = UserRepository(
             persistenceService: userDefaultsPersistenceService,
             networkService: urlSessionNetworkService
         )
         
-        let pairRepository = PairRepository(networkService: urlSessionNetworkService)
+        let pairRepository = PairRepository(networkService: firebaseNetworkService)
         let fcmTokenRepository = FCMTokenRepository(urlSessionNetworkService: urlSessionNetworkService)
         let firebaseMessageRepository = FirebaseMessageRepository(urlSessionNetworkService: urlSessionNetworkService)
 

--- a/Doolda/Doolda/Service/Networks/FirebaseNetworkService.swift
+++ b/Doolda/Doolda/Service/Networks/FirebaseNetworkService.swift
@@ -27,6 +27,10 @@ class FirebaseNetworkService: FirebaseNetworkServiceProtocol {
         }
     }
     
+    static let shared: FirebaseNetworkService = FirebaseNetworkService()
+    
+    private init() { }
+     
     func getDocument(collection: FirebaseCollection, document: String) -> AnyPublisher<[String: Any], Error> {
         return Future { promise in
             Firestore.firestore().collection(collection.rawValue)
@@ -64,6 +68,18 @@ class FirebaseNetworkService: FirebaseNetworkServiceProtocol {
     func setDocument<T: DataTransferable>(collection: FirebaseCollection, document: String, transferable: T) -> AnyPublisher<Void, Error> {
         let dictionary = transferable.dictionary
         return setDocument(collection: collection, document: document, dictionary: dictionary)
+    }
+    
+    func deleteDocument(collection: FirebaseCollection, document: String) -> AnyPublisher<Void, Error> {
+        return Future { promise in
+            Firestore.firestore().collection(collection.rawValue)
+                .document(document)
+                .delete { error in
+                    if let error = error { return promise(.failure(error)) }
+                    return promise(.success(()))
+                }
+        }
+        .eraseToAnyPublisher()
     }
     
     func uploadData(path: String, fileName: String, data: Data) -> AnyPublisher<URL, Error> {

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -61,6 +61,7 @@ class SettingsViewCoordinator: BaseCoordinator {
         DispatchQueue.main.async {
             let userDefaultsPersistenceService = UserDefaultsPersistenceService.shared
             let urlSessionNetworkService = URLSessionNetworkService.shared
+            let firebaseNetworkService = FirebaseNetworkService.shared
 
             let globalFontRepository = GlobalFontRepository(persistenceService: userDefaultsPersistenceService)
             let pushNotificationStateRepository = PushNotificationStateRepository(persistenceService: userDefaultsPersistenceService)
@@ -68,7 +69,7 @@ class SettingsViewCoordinator: BaseCoordinator {
                 persistenceService: userDefaultsPersistenceService,
                 networkService: urlSessionNetworkService
             )
-            let pairRepository = PairRepository(networkService: urlSessionNetworkService)
+            let pairRepository = PairRepository(networkService: firebaseNetworkService)
             let fcmTokenRepository = FCMTokenRepository(urlSessionNetworkService: urlSessionNetworkService)
             let firebaseMessageRepository = FirebaseMessageRepository(urlSessionNetworkService: urlSessionNetworkService)
 


### PR DESCRIPTION
## 이슈 목록

## 특이사항
* FirebaseNetworkService에 document를 삭제하는 메소드가 없어서 `deleteDocument()` 를 추가했습니다.
* pairDocument는 필드가 1개 밖에 없어서 따로 DTO를 구현하지 않았는데, 통일성을 위해 구현하는게 좋아 보입니다. 다들 어떻게 생각하시는지요...? 기존에 `PairDocument` 라는 구조체를, DataTransferable 프로토콜을 채택하는 새로운 DTO로 바꾸면 어떨까 싶습니다. urlSessionNetworkService를 사용 안하게 되면 기존 `PairDocument`는 필요 없어질것 같아서요


## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

