### PR TITLE
(#545) SignUpViewController UI 구현

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		661A840427434FE10077E0E3 /* GetPageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661A840327434FE10077E0E3 /* GetPageUseCase.swift */; };
 		661A8406274351230077E0E3 /* CheckMyTurnUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661A8405274351230077E0E3 /* CheckMyTurnUseCase.swift */; };
 		662A7085277AF51D008AF946 /* AgreementViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662A7084277AF51D008AF946 /* AgreementViewCoordinator.swift */; };
+		663F4AB92826995B00B18B52 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 663F4AB82826995B00B18B52 /* SignUpViewController.swift */; };
 		664893C1273007ED009F03E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664893C0273007ED009F03E2 /* AppDelegate.swift */; };
 		664893C3273007ED009F03E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664893C2273007ED009F03E2 /* SceneDelegate.swift */; };
 		664893CA273007F1009F03E2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 664893C9273007F1009F03E2 /* Assets.xcassets */; };
@@ -538,6 +539,7 @@
 		661A840327434FE10077E0E3 /* GetPageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPageUseCase.swift; sourceTree = "<group>"; };
 		661A8405274351230077E0E3 /* CheckMyTurnUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckMyTurnUseCase.swift; sourceTree = "<group>"; };
 		662A7084277AF51D008AF946 /* AgreementViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreementViewCoordinator.swift; sourceTree = "<group>"; };
+		663F4AB82826995B00B18B52 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		664893BD273007ED009F03E2 /* Doolda.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Doolda.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		664893C0273007ED009F03E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		664893C2273007ED009F03E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -1046,6 +1048,14 @@
 			path = ../ImageUseCaseTest;
 			sourceTree = "<group>";
 		};
+		663F4AB72826992F00B18B52 /* SignUpScene */ = {
+			isa = PBXGroup;
+			children = (
+				663F4AB82826995B00B18B52 /* SignUpViewController.swift */,
+			);
+			path = SignUpScene;
+			sourceTree = "<group>";
+		};
 		664893B4273007ED009F03E2 = {
 			isa = PBXGroup;
 			children = (
@@ -1089,6 +1099,7 @@
 				664893E927300B59009F03E2 /* Support */,
 				1DD0F3602747B10000FC5E65 /* Common */,
 				1DD0F35A2747AE8600FC5E65 /* SplashScene */,
+				663F4AB72826992F00B18B52 /* SignUpScene */,
 				6660E3E92779D91300C2A445 /* AgreementScene */,
 				A40AA69E27F35BE500754E4F /* AuthenticationScene */,
 				1DD0F35E2747AF5A00FC5E65 /* PairingScene */,
@@ -2243,6 +2254,7 @@
 				1D8BE07F2743846A00201E3E /* DiaryCollectionViewHeader.swift in Sources */,
 				66F176112754C370006ACB41 /* RegisterUserUseCaseProtocol.swift in Sources */,
 				FC5FB79027325C4D008AC3D2 /* UserDocument.swift in Sources */,
+				663F4AB92826995B00B18B52 /* SignUpViewController.swift in Sources */,
 				FCD24D7E2743ADC1000203F7 /* PushNotificationStateUseCase.swift in Sources */,
 				319C21D0273BA7D4009CE65C /* ImageRepository.swift in Sources */,
 				310125D8273A6F6B00E43160 /* FileManagerPersistenceServiceProtocol.swift in Sources */,

--- a/Doolda/Doolda/Common/DooldaTextField.swift
+++ b/Doolda/Doolda/Common/DooldaTextField.swift
@@ -56,6 +56,11 @@ class DooldaTextField: UIControl {
         get { return self.textField.placeholder }
         set { self.textField.placeholder = newValue }
     }
+    
+    var returnKeyType: UIReturnKeyType {
+        get { return self.textField.returnKeyType }
+        set { self.textField.returnKeyType = newValue}
+    }
 
     var textContentType: UITextContentType {
         get { return self.textField.textContentType }

--- a/Doolda/Doolda/SignUpScene/SignUpViewController.swift
+++ b/Doolda/Doolda/SignUpScene/SignUpViewController.swift
@@ -210,15 +210,16 @@ final class SignUpViewController: UIViewController {
         
         self.scrollView.addSubview(self.contentView)
         self.contentView.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview()
+            make.top.equalToSuperview().offset(130)
+            make.leading.trailing.equalToSuperview()
             make.centerX.equalToSuperview()
-            make.bottom.equalToSuperview().priority(.low)
             make.centerY.equalToSuperview().priority(.low)
+            make.bottom.equalToSuperview().priority(.low)
         }
         
         self.contentView.addSubview(self.titleLabel)
         self.titleLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(self.view.frame.height * 0.20)
+            make.top.equalToSuperview()
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)
         }

--- a/Doolda/Doolda/SignUpScene/SignUpViewController.swift
+++ b/Doolda/Doolda/SignUpScene/SignUpViewController.swift
@@ -32,11 +32,11 @@ final class SignUpViewController: UIViewController {
         return label
     }()
     
-    private lazy var emailLabel: UILabel = {
-        let label = UILabel()
-        label.text = "이메일"
-        label.textColor = .dooldaSublabel
-        return label
+    private lazy var emailTextField: DooldaTextField = {
+        let textField = DooldaTextField()
+        textField.titleText = "이메일"
+        textField.textContentType = .emailAddress
+        return textField
     }()
     
     private lazy var emailStateLabel: UILabel = {
@@ -46,17 +46,12 @@ final class SignUpViewController: UIViewController {
         return label
     }()
     
-    private lazy var emailTextField: UITextField = {
-        let textField = UITextField()
-        textField.textColor = .dooldaLabel
+    private lazy var passwordTextField: DooldaTextField = {
+        let textField = DooldaTextField()
+        textField.titleText = "비밀번호"
+        textField.textContentType = .password
+        textField.isSecureTextEntry = true
         return textField
-    }()
-    
-    private lazy var passwordLabel: UILabel = {
-        let label = UILabel()
-        label.text = "비밀번호"
-        label.textColor = .dooldaSublabel
-        return label
     }()
     
     private lazy var passwordStateLabel: UILabel = {
@@ -66,19 +61,12 @@ final class SignUpViewController: UIViewController {
         return label
     }()
     
-    private lazy var passwordTextField: UITextField = {
-        let textField = UITextField()
+    private lazy var passwordCheckTextField: DooldaTextField = {
+        let textField = DooldaTextField()
+        textField.titleText = "비밀번호 확인"
         textField.textContentType = .password
         textField.isSecureTextEntry = true
-        textField.textColor = .dooldaLabel
         return textField
-    }()
-    
-    private lazy var passwordCheckLabel: UILabel = {
-        let label = UILabel()
-        label.text = "비밀번호 확인"
-        label.textColor = .dooldaSublabel
-        return label
     }()
     
     private lazy var passwordCheckStateLabel: UILabel = {
@@ -88,74 +76,33 @@ final class SignUpViewController: UIViewController {
         return label
     }()
     
-    private lazy var passwordCheckTextField: UITextField = {
-        let textField = UITextField()
-        textField.textContentType = .password
-        textField.isSecureTextEntry = true
-        textField.textColor = .dooldaLabel
-        return textField
-    }()
-    
-    private lazy var emailDivider: UIView = {
-        let view = UIView()
-        view.backgroundColor = .dooldaSublabel
-        return view
-    }()
-    
     private lazy var emailInfoStack: UIStackView = {
-        let titleStackView = UIStackView(arrangedSubviews: [self.emailLabel, self.emailStateLabel])
-        titleStackView.distribution = .equalSpacing
-        titleStackView.axis = .horizontal
         let stackView = UIStackView(arrangedSubviews: [
-            titleStackView,
-            emailTextField,
-            self.emailDivider
+            self.emailTextField,
+            self.emailStateLabel
         ])
         stackView.axis = .vertical
-        stackView.spacing = 24
-        stackView.setCustomSpacing(6, after: self.emailTextField)
+        stackView.spacing = 7
         return stackView
     }()
-    
-    private lazy var passwordDivider: UIView = {
-        let view = UIView()
-        view.backgroundColor = .dooldaSublabel
-        return view
-    }()
-    
+
     private lazy var passwordInfoStack: UIStackView = {
-        let titleStackView = UIStackView(arrangedSubviews: [self.passwordLabel, self.passwordStateLabel])
-        titleStackView.distribution = .equalSpacing
-        titleStackView.axis = .horizontal
         let stackView = UIStackView(arrangedSubviews: [
-            titleStackView,
             self.passwordTextField,
-            self.passwordDivider
+            self.passwordStateLabel
         ])
         stackView.axis = .vertical
-        stackView.spacing = 24
-        stackView.setCustomSpacing(6, after: self.passwordTextField)
+        stackView.spacing = 7
         return stackView
     }()
-    
-    private lazy var passwordCheckDivider: UIView = {
-        let view = UIView()
-        view.backgroundColor = .dooldaSublabel
-        return view
-    }()
-    
+
     private lazy var passwordCheckInfoStack: UIStackView = {
-        let titleStackView = UIStackView(arrangedSubviews: [self.passwordCheckLabel, self.passwordCheckStateLabel])
-        titleStackView.distribution = .equalSpacing
-        titleStackView.axis = .horizontal
         let stackView = UIStackView(arrangedSubviews: [
-            titleStackView,
             self.passwordCheckTextField,
-            self.passwordCheckDivider
+            self.passwordCheckStateLabel
         ])
         stackView.axis = .vertical
-        stackView.spacing = 24
-        stackView.setCustomSpacing(6, after: self.passwordCheckTextField)
+        stackView.spacing = 7
         return stackView
     }()
     
@@ -181,11 +128,12 @@ final class SignUpViewController: UIViewController {
         return button
     }()
     
-    private lazy var backButton: DooldaButton = {
-        let button = DooldaButton()
-        button.setTitle("돌아가기", for: .normal)
+    private lazy var signInButton: UIButton = {
+        var button = UIButton()
+        let attributes: [NSAttributedString.Key: Any] = [.underlineStyle: NSUnderlineStyle.single.rawValue]
+        let attributeString = NSMutableAttributedString(string: "이미 계정이 있으신가요?", attributes: attributes)
+        button.setAttributedTitle(attributeString, for: .normal)
         button.setTitleColor(.dooldaLabel, for: .normal)
-        button.backgroundColor = .dooldaHighlighted
         return button
     }()
     
@@ -204,8 +152,15 @@ final class SignUpViewController: UIViewController {
         self.navigationController?.navigationBar.isHidden = true
         
         self.view.addSubview(self.scrollView)
+        self.view.addSubview(self.signInButton)
         self.scrollView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.top.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(self.signInButton.snp.top).offset(-12)
+        }
+        
+        self.signInButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-38)
         }
         
         self.scrollView.addSubview(self.contentView)
@@ -237,18 +192,6 @@ final class SignUpViewController: UIViewController {
             make.trailing.equalToSuperview().offset(-16)
         }
         
-        self.emailDivider.snp.makeConstraints { make in
-            make.height.equalTo(1)
-        }
-        
-        self.passwordDivider.snp.makeConstraints { make in
-            make.height.equalTo(1)
-        }
-        
-        self.passwordCheckDivider.snp.makeConstraints { make in
-            make.height.equalTo(1)
-        }
-        
         self.contentView.addSubview(self.signUpButton)
         self.signUpButton.snp.makeConstraints { make in
             make.top.equalTo(self.signUpInfoStackView.snp.bottom).offset(44)
@@ -256,30 +199,15 @@ final class SignUpViewController: UIViewController {
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)
         }
-        
-        self.contentView.addSubview(self.backButton)
-        self.backButton.snp.makeConstraints { make in
-            make.top.equalTo(self.signUpButton.snp.bottom).offset(24)
-            make.height.equalTo(44)
-            make.leading.equalToSuperview().offset(16)
-            make.trailing.equalToSuperview().offset(-16)
-            make.bottom.equalToSuperview().offset(-20)
-        }
     }
     
     private func configureFont() {
         self.titleLabel.font = UIFont(name: FontType.dovemayo.name, size: 72)
         self.subtitleLabel.font = UIFont(name: FontType.dovemayo.name, size: 18)
-        self.emailLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
         self.emailStateLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
-        self.emailTextField.font = UIFont(name: FontType.dovemayo.name, size: 14)
-        self.passwordLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
         self.passwordStateLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
-        self.passwordTextField.font = UIFont(name: FontType.dovemayo.name, size: 14)
-        self.passwordCheckLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
         self.passwordCheckStateLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
-        self.passwordCheckTextField.font = UIFont(name: FontType.dovemayo.name, size: 14)
         self.signUpButton.titleLabel?.font = UIFont(name: FontType.dovemayo.name, size: 14)
-        self.backButton.titleLabel?.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.signInButton.titleLabel?.font = UIFont(name: FontType.dovemayo.name, size: 16)
     }
 }

--- a/Doolda/Doolda/SignUpScene/SignUpViewController.swift
+++ b/Doolda/Doolda/SignUpScene/SignUpViewController.swift
@@ -13,6 +13,9 @@ final class SignUpViewController: UIViewController {
     
     // MARK: - Subviews
     
+    private lazy var scrollView: UIScrollView = UIScrollView()
+    private lazy var contentView: UIView = UIView()
+    
     private lazy var titleLabel: UILabel = {
         var label = UILabel()
         label.text = "둘다"
@@ -206,20 +209,33 @@ final class SignUpViewController: UIViewController {
         self.view.backgroundColor = .dooldaBackground
         self.navigationController?.navigationBar.isHidden = true
         
-        self.view.addSubview(self.titleLabel)
+        self.view.addSubview(self.scrollView)
+        self.scrollView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        self.scrollView.addSubview(self.contentView)
+        self.contentView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().priority(.low)
+            make.centerY.equalToSuperview().priority(.low)
+        }
+        
+        self.contentView.addSubview(self.titleLabel)
         self.titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(self.view.frame.height * 0.20)
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)
         }
         
-        self.view.addSubview(self.subtitleLabel)
+        self.contentView.addSubview(self.subtitleLabel)
         self.subtitleLabel.snp.makeConstraints { make in
             make.top.equalTo(self.titleLabel.snp.bottom).offset(18)
             make.centerX.equalToSuperview()
         }
         
-        self.view.addSubview(self.signUpInfoStackView)
+        self.contentView.addSubview(self.signUpInfoStackView)
         self.signUpInfoStackView.snp.makeConstraints { make in
             make.top.equalTo(self.subtitleLabel.snp.bottom).offset(42)
             make.leading.equalToSuperview().offset(16)
@@ -250,7 +266,7 @@ final class SignUpViewController: UIViewController {
             make.height.equalTo(1)
         }
         
-        self.view.addSubview(self.signUpButton)
+        self.contentView.addSubview(self.signUpButton)
         self.signUpButton.snp.makeConstraints { make in
             make.top.equalTo(self.signUpInfoStackView.snp.bottom).offset(44)
             make.height.equalTo(44)
@@ -258,12 +274,13 @@ final class SignUpViewController: UIViewController {
             make.trailing.equalToSuperview().offset(-16)
         }
         
-        self.view.addSubview(self.backButton)
+        self.contentView.addSubview(self.backButton)
         self.backButton.snp.makeConstraints { make in
             make.top.equalTo(self.signUpButton.snp.bottom).offset(24)
             make.height.equalTo(44)
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)
+            make.bottom.equalToSuperview().offset(-20)
         }
     }
     

--- a/Doolda/Doolda/SignUpScene/SignUpViewController.swift
+++ b/Doolda/Doolda/SignUpScene/SignUpViewController.swift
@@ -48,8 +48,6 @@ final class SignUpViewController: UIViewController {
     
     private lazy var emailTextField: UITextField = {
         let textField = UITextField()
-        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: 0))
-        textField.leftViewMode = .always
         textField.textColor = .dooldaLabel
         return textField
     }()
@@ -72,8 +70,6 @@ final class SignUpViewController: UIViewController {
         let textField = UITextField()
         textField.textContentType = .password
         textField.isSecureTextEntry = true
-        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: 0))
-        textField.leftViewMode = .always
         textField.textColor = .dooldaLabel
         return textField
     }()
@@ -96,8 +92,6 @@ final class SignUpViewController: UIViewController {
         let textField = UITextField()
         textField.textContentType = .password
         textField.isSecureTextEntry = true
-        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: 0))
-        textField.leftViewMode = .always
         textField.textColor = .dooldaLabel
         return textField
     }()
@@ -240,18 +234,6 @@ final class SignUpViewController: UIViewController {
             make.top.equalTo(self.subtitleLabel.snp.bottom).offset(42)
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)
-        }
-        
-        self.emailTextField.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().offset(-30)
-        }
-        
-        self.passwordTextField.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().offset(-30)
-        }
-        
-        self.passwordCheckTextField.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().offset(-30)
         }
         
         self.emailDivider.snp.makeConstraints { make in

--- a/Doolda/Doolda/SignUpScene/SignUpViewController.swift
+++ b/Doolda/Doolda/SignUpScene/SignUpViewController.swift
@@ -184,6 +184,14 @@ final class SignUpViewController: UIViewController {
         return button
     }()
     
+    private lazy var backButton: DooldaButton = {
+        let button = DooldaButton()
+        button.setTitle("돌아가기", for: .normal)
+        button.setTitleColor(.dooldaLabel, for: .normal)
+        button.backgroundColor = .dooldaHighlighted
+        return button
+    }()
+    
     // MARK: - Lifecycle Methods
     
     override func viewDidLoad() {
@@ -249,6 +257,14 @@ final class SignUpViewController: UIViewController {
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)
         }
+        
+        self.view.addSubview(self.backButton)
+        self.backButton.snp.makeConstraints { make in
+            make.top.equalTo(self.signUpButton.snp.bottom).offset(24)
+            make.height.equalTo(44)
+            make.leading.equalToSuperview().offset(16)
+            make.trailing.equalToSuperview().offset(-16)
+        }
     }
     
     private func configureFont() {
@@ -264,5 +280,6 @@ final class SignUpViewController: UIViewController {
         self.passwordCheckStateLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
         self.passwordCheckTextField.font = UIFont(name: FontType.dovemayo.name, size: 14)
         self.signUpButton.titleLabel?.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.backButton.titleLabel?.font = UIFont(name: FontType.dovemayo.name, size: 14)
     }
 }

--- a/Doolda/Doolda/SignUpScene/SignUpViewController.swift
+++ b/Doolda/Doolda/SignUpScene/SignUpViewController.swift
@@ -1,0 +1,268 @@
+//
+//  SignUpViewController.swift
+//  Doolda
+//
+//  Created by 정지승 on 2022/05/07.
+//
+
+import UIKit
+
+import SnapKit
+
+final class SignUpViewController: UIViewController {
+    
+    // MARK: - Subviews
+    
+    private lazy var titleLabel: UILabel = {
+        var label = UILabel()
+        label.text = "둘다"
+        label.textColor = .dooldaLabel
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private lazy var subtitleLabel: UILabel = {
+        var label = UILabel()
+        label.text = "회원가입을 위한 정보를 입력해주세요."
+        label.textColor = .dooldaLabel
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private lazy var emailLabel: UILabel = {
+        let label = UILabel()
+        label.text = "이메일"
+        label.textColor = .dooldaSublabel
+        return label
+    }()
+    
+    private lazy var emailStateLabel: UILabel = {
+        let label = UILabel()
+        label.text = "이메일 형식이 올바르지 않습니다."
+        label.textColor = .red
+        return label
+    }()
+    
+    private lazy var emailTextField: UITextField = {
+        let textField = UITextField()
+        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: 0))
+        textField.leftViewMode = .always
+        textField.textColor = .dooldaLabel
+        return textField
+    }()
+    
+    private lazy var passwordLabel: UILabel = {
+        let label = UILabel()
+        label.text = "비밀번호"
+        label.textColor = .dooldaSublabel
+        return label
+    }()
+    
+    private lazy var passwordStateLabel: UILabel = {
+        let label = UILabel()
+        label.text = "비밀번호 형식이 올바르지 않습니다."
+        label.textColor = .red
+        return label
+    }()
+    
+    private lazy var passwordTextField: UITextField = {
+        let textField = UITextField()
+        textField.textContentType = .password
+        textField.isSecureTextEntry = true
+        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: 0))
+        textField.leftViewMode = .always
+        textField.textColor = .dooldaLabel
+        return textField
+    }()
+    
+    private lazy var passwordCheckLabel: UILabel = {
+        let label = UILabel()
+        label.text = "비밀번호 확인"
+        label.textColor = .dooldaSublabel
+        return label
+    }()
+    
+    private lazy var passwordCheckStateLabel: UILabel = {
+        let label = UILabel()
+        label.text = "비밀번호가 일치하지 않습니다."
+        label.textColor = .red
+        return label
+    }()
+    
+    private lazy var passwordCheckTextField: UITextField = {
+        let textField = UITextField()
+        textField.textContentType = .password
+        textField.isSecureTextEntry = true
+        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: 0))
+        textField.leftViewMode = .always
+        textField.textColor = .dooldaLabel
+        return textField
+    }()
+    
+    private lazy var emailDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .dooldaSublabel
+        return view
+    }()
+    
+    private lazy var emailInfoStack: UIStackView = {
+        let titleStackView = UIStackView(arrangedSubviews: [self.emailLabel, self.emailStateLabel])
+        titleStackView.distribution = .equalSpacing
+        titleStackView.axis = .horizontal
+        let stackView = UIStackView(arrangedSubviews: [
+            titleStackView,
+            emailTextField,
+            self.emailDivider
+        ])
+        stackView.axis = .vertical
+        stackView.spacing = 24
+        stackView.setCustomSpacing(6, after: self.emailTextField)
+        return stackView
+    }()
+    
+    private lazy var passwordDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .dooldaSublabel
+        return view
+    }()
+    
+    private lazy var passwordInfoStack: UIStackView = {
+        let titleStackView = UIStackView(arrangedSubviews: [self.passwordLabel, self.passwordStateLabel])
+        titleStackView.distribution = .equalSpacing
+        titleStackView.axis = .horizontal
+        let stackView = UIStackView(arrangedSubviews: [
+            titleStackView,
+            self.passwordTextField,
+            self.passwordDivider
+        ])
+        stackView.axis = .vertical
+        stackView.spacing = 24
+        stackView.setCustomSpacing(6, after: self.passwordTextField)
+        return stackView
+    }()
+    
+    private lazy var passwordCheckDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .dooldaSublabel
+        return view
+    }()
+    
+    private lazy var passwordCheckInfoStack: UIStackView = {
+        let titleStackView = UIStackView(arrangedSubviews: [self.passwordCheckLabel, self.passwordCheckStateLabel])
+        titleStackView.distribution = .equalSpacing
+        titleStackView.axis = .horizontal
+        let stackView = UIStackView(arrangedSubviews: [
+            titleStackView,
+            self.passwordCheckTextField,
+            self.passwordCheckDivider
+        ])
+        stackView.axis = .vertical
+        stackView.spacing = 24
+        stackView.setCustomSpacing(6, after: self.passwordCheckTextField)
+        return stackView
+    }()
+    
+    private lazy var signUpInfoStackView: UIStackView = {
+        let stackView = UIStackView(
+            arrangedSubviews: [
+                emailInfoStack,
+                passwordInfoStack,
+                passwordCheckInfoStack
+            ]
+        )
+        stackView.axis = .vertical
+        stackView.spacing = 18
+        return stackView
+    }()
+    
+    private lazy var signUpButton: DooldaButton = {
+        let button = DooldaButton()
+        button.setTitle("회원가입", for: .normal)
+        button.setTitleColor(.dooldaLabel, for: .normal)
+        button.backgroundColor = .dooldaHighlighted
+        button.isEnabled = false
+        return button
+    }()
+    
+    // MARK: - Lifecycle Methods
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        configureFont()
+    }
+    
+    // MARK: - Helpers
+    
+    private func configureUI() {
+        self.view.backgroundColor = .dooldaBackground
+        self.navigationController?.navigationBar.isHidden = true
+        
+        self.view.addSubview(self.titleLabel)
+        self.titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(self.view.frame.height * 0.20)
+            make.leading.equalToSuperview().offset(16)
+            make.trailing.equalToSuperview().offset(-16)
+        }
+        
+        self.view.addSubview(self.subtitleLabel)
+        self.subtitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(18)
+            make.centerX.equalToSuperview()
+        }
+        
+        self.view.addSubview(self.signUpInfoStackView)
+        self.signUpInfoStackView.snp.makeConstraints { make in
+            make.top.equalTo(self.subtitleLabel.snp.bottom).offset(42)
+            make.leading.equalToSuperview().offset(16)
+            make.trailing.equalToSuperview().offset(-16)
+        }
+        
+        self.emailTextField.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-30)
+        }
+        
+        self.passwordTextField.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-30)
+        }
+        
+        self.passwordCheckTextField.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-30)
+        }
+        
+        self.emailDivider.snp.makeConstraints { make in
+            make.height.equalTo(1)
+        }
+        
+        self.passwordDivider.snp.makeConstraints { make in
+            make.height.equalTo(1)
+        }
+        
+        self.passwordCheckDivider.snp.makeConstraints { make in
+            make.height.equalTo(1)
+        }
+        
+        self.view.addSubview(self.signUpButton)
+        self.signUpButton.snp.makeConstraints { make in
+            make.top.equalTo(self.signUpInfoStackView.snp.bottom).offset(44)
+            make.height.equalTo(44)
+            make.leading.equalToSuperview().offset(16)
+            make.trailing.equalToSuperview().offset(-16)
+        }
+    }
+    
+    private func configureFont() {
+        self.titleLabel.font = UIFont(name: FontType.dovemayo.name, size: 72)
+        self.subtitleLabel.font = UIFont(name: FontType.dovemayo.name, size: 18)
+        self.emailLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.emailStateLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.emailTextField.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.passwordLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.passwordStateLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.passwordTextField.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.passwordCheckLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.passwordCheckStateLabel.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.passwordCheckTextField.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        self.signUpButton.titleLabel?.font = UIFont(name: FontType.dovemayo.name, size: 14)
+    }
+}


### PR DESCRIPTION
## 이슈 목록
- [ ] #545 

| iPhone 11 Pro Max | iPhone SE |
| --- | --- |
| <img width="466" alt="image" src="https://user-images.githubusercontent.com/49086747/168465407-572d701d-f4dc-4523-ae50-ce8651a072ea.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/49086747/168465397-34479534-a241-4254-904a-89a520173f2c.png"> |

## 특이사항
* UIResponder를 확장하여 만들어진 keyboardHeightPublisher를 활용하여 scrollview의 contentOffset을 조절 하려고 했으나, textfield간 이동시 keyboardHeight가 0으로 반환되어 정상적으로 처리가 안되는 현상이 발생해 "keyboardWillShowNotification", "keyboardWillHideNotification" 두 노티를 직접 받아 처리하도록 구현했습니다.
* 키보드에서 다음 버튼 터치 시 다음 TextField로 포커스를 옮겨주고 싶은데 TextField가 DooldaTextField로 감싸져 있어 어떻게 처리할지 고민이 드네요 조언좀 부탁드려요

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

