### PR TITLE
로그인 화면 구현

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 		A40AA6A027F35C0C00754E4F /* AuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40AA69F27F35C0C00754E4F /* AuthenticationViewController.swift */; };
 		A40AA6A227F362A100754E4F /* AuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40AA6A127F362A100754E4F /* AuthenticationViewModel.swift */; };
 		A40AA6A627F369EA00754E4F /* AuthenticationViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40AA6A527F369EA00754E4F /* AuthenticationViewCoordinator.swift */; };
+		A4527A7E2829175700760AB0 /* DooldaTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4527A7D2829175700760AB0 /* DooldaTextField.swift */; };
 		FC19598A274284E200AB6059 /* StickerPickerBottomSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC195989274284E200AB6059 /* StickerPickerBottomSheetViewModel.swift */; };
 		FC23C228274E17C200EBAE4C /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC23C227274E17C200EBAE4C /* PageDetailViewController.swift */; };
 		FC28CB32274609F300BA47BB /* TextUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC28CB31274609F300BA47BB /* TextUseCase.swift */; };
@@ -613,6 +614,7 @@
 		A40AA69F27F35C0C00754E4F /* AuthenticationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewController.swift; sourceTree = "<group>"; };
 		A40AA6A127F362A100754E4F /* AuthenticationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewModel.swift; sourceTree = "<group>"; };
 		A40AA6A527F369EA00754E4F /* AuthenticationViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewCoordinator.swift; sourceTree = "<group>"; };
+		A4527A7D2829175700760AB0 /* DooldaTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DooldaTextField.swift; sourceTree = "<group>"; };
 		FC195989274284E200AB6059 /* StickerPickerBottomSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerPickerBottomSheetViewModel.swift; sourceTree = "<group>"; };
 		FC23C227274E17C200EBAE4C /* PageDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		FC28CB31274609F300BA47BB /* TextUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextUseCase.swift; sourceTree = "<group>"; };
@@ -946,6 +948,7 @@
 				1D9DC0A0274A47D50060587B /* DooldaButton.swift */,
 				1DD58BD52754ACA600B93184 /* DiaryPageView.swift */,
 				664C31CC27EC54D1009B7C3A /* DooldaCheckBox.swift */,
+				A4527A7D2829175700760AB0 /* DooldaTextField.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -2228,6 +2231,7 @@
 				66F1760F2754C334006ACB41 /* RefreshUserUseCaseProtocol.swift in Sources */,
 				1DDADCB4274BCE63000330C9 /* Secrets.swift in Sources */,
 				3161EE9827436EC600B922DD /* StickerPickerView.swift in Sources */,
+				A4527A7E2829175700760AB0 /* DooldaTextField.swift in Sources */,
 				1D6232F527313D8E00A9AD6B /* UIView+Extensions.swift in Sources */,
 				66CD6464273D125F00E55C03 /* CGImage+Extensions.swift in Sources */,
 				FC51FA6D274C89330069D39C /* FontSizeControlView.swift in Sources */,

--- a/Doolda/Doolda/AuthenticationScene/AuthenticationViewController.swift
+++ b/Doolda/Doolda/AuthenticationScene/AuthenticationViewController.swift
@@ -151,6 +151,7 @@ class AuthenticationViewController: UIViewController {
                 )
             }
             .store(in: &self.cancellables)
+
     }
 }
 

--- a/Doolda/Doolda/AuthenticationScene/AuthenticationViewController.swift
+++ b/Doolda/Doolda/AuthenticationScene/AuthenticationViewController.swift
@@ -32,29 +32,47 @@ class AuthenticationViewController: UIViewController {
         return label
     }()
 
-    private lazy var subtitleLabel: UILabel = {
-        var label = UILabel()
-        label.text = "서비스 이용을 위해 회원가입이 필요해요."
-        label.font = UIFont(name: FontType.dovemayo.name, size: 18)
-        label.textColor = UIColor.dooldaLabel
-        label.textAlignment = .center
-        return label
+    private lazy var emailTextField: DooldaTextField = {
+        var textField = DooldaTextField()
+        textField.titleText = "이메일"
+        textField.placeholder = "이메일을 입력해주세요"
+        textField.textContentType = .emailAddress
+        return textField
+    }()
+    
+    private lazy var passwordTextField: DooldaTextField = {
+        var textField = DooldaTextField()
+        textField.titleText = "비밀번호"
+        textField.placeholder = "비밀번호를 입력해주세요"
+        textField.textContentType = .newPassword
+        textField.isSecureTextEntry = true
+        return textField
+    }()
+    
+    private lazy var createAccountButton: UIButton = {
+        var button = UIButton()
+        let attributes: [NSAttributedString.Key: Any] = [.underlineStyle: NSUnderlineStyle.single.rawValue]
+        let attributeString = NSMutableAttributedString(string: "계정이 없으신가요?", attributes: attributes)
+        button.setAttributedTitle(attributeString, for: .normal)
+        button.titleLabel?.font = UIFont(name: FontType.dovemayo.name, size: 16)
+        button.titleLabel?.textAlignment = .left
+        button.setTitleColor(.dooldaLabel, for: .normal)
+        return button
+    }()
+    
+    private lazy var emailLoginButton: DooldaButton = {
+        var button = DooldaButton()
+        button.setTitle("로그인하기", for: .normal)
+        button.setTitleColor(.dooldaLabel, for: .normal)
+        button.backgroundColor = .dooldaHighlighted
+        button.titleLabel?.font = UIFont(name: FontType.dovemayo.name, size: 16)
+        return button
     }()
 
-    private lazy var appleLoginButton = ASAuthorizationAppleIDButton()
-
-    private lazy var leftHedgehogImage: UIImageView = {
-        var imageView = UIImageView()
-        imageView.image = UIImage.hedgehogWriting
-        imageView.contentMode = .scaleAspectFill
-        return imageView
-    }()
-
-    private lazy var rightHedgehogImage: UIImageView = {
-        var imageView = UIImageView()
-        imageView.image = UIImage.hedgehogWriting?.withHorizontallyFlippedOrientation()
-        imageView.contentMode = .scaleAspectFill
-        return imageView
+    private lazy var appleLoginButton: ASAuthorizationAppleIDButton = {
+        let button = ASAuthorizationAppleIDButton()
+        button.cornerRadius = 22
+        return button
     }()
 
     // MARK: - Private Properties
@@ -81,41 +99,46 @@ class AuthenticationViewController: UIViewController {
 
     private func configureUI() {
         self.view.backgroundColor = .dooldaBackground
+        self.navigationItem.hidesBackButton = true
 
         self.view.addSubview(self.titleLabel)
         self.titleLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview()
             make.trailing.equalToSuperview()
-            make.top.equalToSuperview().offset(self.view.frame.height * 0.20)
+            make.top.equalToSuperview().offset(130)
         }
-
-        self.view.addSubview(self.subtitleLabel)
-        self.subtitleLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview()
-            make.trailing.equalToSuperview()
-            make.top.equalTo(self.titleLabel.snp.bottom).offset(30)
-        }
-
-        self.view.addSubview(self.appleLoginButton)
-        self.appleLoginButton.snp.makeConstraints { make in
-            make.height.equalTo(48)
+        
+        self.view.addSubview(self.emailTextField)
+        self.emailTextField.snp.makeConstraints { make in
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(60)
             make.leading.equalToSuperview().offset(16)
             make.trailing.equalToSuperview().offset(-16)
-            make.centerY.equalToSuperview()
+        }
+        
+        self.view.addSubview(self.passwordTextField)
+        self.passwordTextField.snp.makeConstraints { make in
+            make.top.equalTo(self.emailTextField.snp.bottom).offset(18)
+            make.leading.trailing.equalTo(self.emailTextField)
+        }
+        
+        self.view.addSubview(self.createAccountButton)
+        self.createAccountButton.snp.makeConstraints { make in
+            make.top.equalTo(self.passwordTextField.snp.bottom).offset(8)
+            make.leading.equalTo(self.passwordTextField)
         }
 
-        self.view.addSubview(self.leftHedgehogImage)
-        self.leftHedgehogImage.snp.makeConstraints { make in
-            make.height.equalTo(360)
-            make.trailing.equalTo(self.view.snp.centerX).offset(-32)
-            make.bottom.equalToSuperview()
+        self.view.addSubview(self.emailLoginButton)
+        self.emailLoginButton.snp.makeConstraints { make in
+            make.top.equalTo(self.createAccountButton.snp.bottom).offset(17)
+            make.height.equalTo(44)
+            make.leading.trailing.equalTo(self.emailTextField)
         }
-
-        self.view.addSubview(self.rightHedgehogImage)
-        self.rightHedgehogImage.snp.makeConstraints { make in
-            make.height.equalTo(360)
-            make.leading.equalTo(self.view.snp.centerX).offset(32)
-            make.bottom.equalToSuperview()
+        
+        self.view.addSubview(self.appleLoginButton)
+        self.appleLoginButton.snp.makeConstraints { make in
+            make.top.equalTo(self.emailLoginButton.snp.bottom).offset(24)
+            make.height.equalTo(48)
+            make.leading.trailing.equalTo(self.emailTextField)
         }
     }
 

--- a/Doolda/Doolda/Common/DooldaTextField.swift
+++ b/Doolda/Doolda/Common/DooldaTextField.swift
@@ -1,0 +1,90 @@
+//
+//  DooldaTextField.swift
+//  Doolda
+//
+//  Created by heizel.nut on 2022/05/09.
+//
+
+import Combine
+import UIKit
+
+import SnapKit
+
+class DooldaTextField: UIView {
+    
+    // MARK: - Subviews
+    
+    private lazy var titleLable: UILabel = {
+        var label = UILabel()
+        label.textColor = .dooldaSublabel
+        label.textAlignment = .left
+        label.font = UIFont(name: FontType.dovemayo.name, size: 14)
+        return label
+    }()
+    
+    private lazy var textField: UITextField = {
+        let textField = UITextField()
+        textField.font = UIFont(name: FontType.dovemayo.name, size: 16)
+        textField.textColor = .dooldaLabel
+        textField.leftView = UIView(frame: .init(x: 0, y: 0, width: 25, height: 0))
+        textField.leftViewMode = .always
+        return textField
+    }()
+    
+    private lazy var divider: UIView = {
+        let divider = UIView()
+        divider.backgroundColor = .dooldaSublabel
+        return divider
+    }()
+    
+    // MARK: - Public Properties
+    
+    var titleText: String? {
+        get { return self.titleLable.text }
+        set { self.titleLable.text = newValue }
+    }
+     
+    var placeholder: String? {
+        get { return self.textField.placeholder }
+        set { self.textField.placeholder = newValue }
+    }
+    
+    // MARK: - Initializers
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.configureUI()
+    }
+
+    // MARK: - Helpers
+    
+    private func configureUI() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(70)
+        }
+        
+        self.addSubview(self.titleLable)
+        self.titleLable.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+        }
+        
+        self.addSubview(self.textField)
+        self.textField.snp.makeConstraints { make in
+            make.top.equalTo(self.titleLable.snp.bottom).offset(24)
+            make.leading.trailing.equalTo(self.titleLable)
+        }
+        
+        self.addSubview(self.divider)
+        self.divider.snp.makeConstraints { make in
+            make.bottom.equalTo(self.textField).offset(6)
+            make.leading.trailing.equalTo(self.titleLable)
+            make.height.equalTo(1)
+        }
+    }
+    
+}

--- a/Doolda/Doolda/Common/DooldaTextField.swift
+++ b/Doolda/Doolda/Common/DooldaTextField.swift
@@ -10,7 +10,7 @@ import UIKit
 
 import SnapKit
 
-class DooldaTextField: UIView {
+class DooldaTextField: UIControl {
     
     // MARK: - Subviews
     
@@ -38,25 +38,33 @@ class DooldaTextField: UIView {
     }()
     
     // MARK: - Public Properties
+
+    var returnPublisher: AnyPublisher<UIControl, Never> {
+        self.textField.publisher(for: .editingDidEndOnExit).eraseToAnyPublisher()
+    }
+
+    var text: String? {
+        get { return self.textField.text }
+    }
     
     var titleText: String? {
         get { return self.titleLable.text }
         set { self.titleLable.text = newValue }
     }
-     
+
     var placeholder: String? {
         get { return self.textField.placeholder }
         set { self.textField.placeholder = newValue }
     }
-    
+
     var textContentType: UITextContentType {
         get { return self.textField.textContentType }
         set { self.textField.textContentType = newValue }
     }
-    
+
     var isSecureTextEntry: Bool {
         get { return self.textField.isSecureTextEntry }
-        set { self.textField.isSecureTextEntry = newValue } 
+        set { self.textField.isSecureTextEntry = newValue }
     }
     
     // MARK: - Initializers
@@ -80,7 +88,8 @@ class DooldaTextField: UIView {
         
         self.addSubview(self.titleLable)
         self.titleLable.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview()
+            make.top.equalTo(self)
+            make.leading.trailing.equalToSuperview()
         }
         
         self.addSubview(self.textField)
@@ -91,10 +100,11 @@ class DooldaTextField: UIView {
         
         self.addSubview(self.divider)
         self.divider.snp.makeConstraints { make in
-            make.bottom.equalTo(self.textField).offset(6)
+            make.bottom.equalTo(self)
             make.leading.trailing.equalTo(self.titleLable)
             make.height.equalTo(1)
         }
+
     }
     
 }

--- a/Doolda/Doolda/Common/DooldaTextField.swift
+++ b/Doolda/Doolda/Common/DooldaTextField.swift
@@ -49,6 +49,16 @@ class DooldaTextField: UIView {
         set { self.textField.placeholder = newValue }
     }
     
+    var textContentType: UITextContentType {
+        get { return self.textField.textContentType }
+        set { self.textField.textContentType = newValue }
+    }
+    
+    var isSecureTextEntry: Bool {
+        get { return self.textField.isSecureTextEntry }
+        set { self.textField.isSecureTextEntry = newValue } 
+    }
+    
     // MARK: - Initializers
     
     override init(frame: CGRect) {

--- a/Doolda/Doolda/SplashScene/SplashViewCoordinator.swift
+++ b/Doolda/Doolda/SplashScene/SplashViewCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class SplashViewCoordinator: BaseCoordinator {
     
-    //MARK: - Nested enum
+    // MARK: - Nested enum
 
     enum Notifications {
         static let userNotLoggedIn = Notification.Name("userNotLoggedIn")


### PR DESCRIPTION
## 이슈 목록
- [x] #547: Login View

## ScreenShots

| iPhone 13 | iPhone 13 다크모드 | iPhone 12 mini |
| --- | --- | --- |
| <img width="301" src="https://user-images.githubusercontent.com/61934702/167402036-1c8fa22e-3c9a-4470-9f47-e1abf8da3473.PNG"> | <img width="301" src="https://user-images.githubusercontent.com/61934702/167402093-4b196180-9759-44e8-8efb-a3fea2eef2c0.PNG"> | <img width="301" src="https://user-images.githubusercontent.com/61934702/167402100-632c1cd0-2896-4948-8ad6-9177e7c18ba9.PNG">

## 특이사항
* 텍스트 필드가 자주 사용될것 같아서 `DooldaTextField` 를 만들었읍니다.
* TextField의 return키 동작은 아직 구현 안했습니다 ^^;;;
* 기존의 Authentication 이라는 명칭을 Login으로 변경했습니다
* 최대한 Figma 대로 뷰를 그렸는데 어색한 부분이 있으면 리뷰 남겨주세요

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

