### PR TITLE
uid로 ddid를 가져올 수 있도록 구현

### DIFF
--- a/Doolda/Doolda/AuthenticationScene/AuthenticationViewModel.swift
+++ b/Doolda/Doolda/AuthenticationScene/AuthenticationViewModel.swift
@@ -141,8 +141,12 @@ final class AuthenticationViewModel: AuthenticationViewModelProtocol {
     
     private func validateUser(with authDataResult: AuthDataResult?) {
         guard let user = authDataResult?.user else { return self.error = AuthenticatoinError.missingAuthDataResult }
+        
         self.getMyIdUseCase.getMyId(for: user.uid)
-            .sink { [weak self] ddid in
+            .sink { [weak self] completion in
+                guard case .failure(let error) = completion else { return }
+                self?.error = error
+            } receiveValue: { [weak self] ddid in
                 guard let self = self else { return }
                 guard let ddid = ddid else {
                     self.createUserUseCase.create(uid: user.uid)

--- a/Doolda/Doolda/Data/Repositories/UserRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/UserRepository.swift
@@ -62,14 +62,10 @@ class UserRepository: UserRepositoryProtocol {
         return Just(DDID(from: userIdString)).eraseToAnyPublisher()
     }
     
-    
-    // FIXME: uid to ddid 맵핑 컬랙션을 정의 후 수정해야함.
     func getMyId(for uid: String) -> AnyPublisher<DDID?, Error> {
-        let conditions = ["uid": uid]
-        
-        return self.firebaseNetworkService.getDocuments(collection: .ddidDictionary, conditions: conditions)
+        return self.firebaseNetworkService.getDocument(collection: .ddidDictionary, document: uid)
             .map { data -> DDID? in
-                guard let ddidString = data.first?["ddid"] as? String,
+                guard let ddidString = data["ddid"] as? String,
                       let ddid = DDID(from: ddidString) else { return nil }
                 return ddid
             }

--- a/Doolda/Doolda/Data/Repositories/UserRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/UserRepository.swift
@@ -62,6 +62,20 @@ class UserRepository: UserRepositoryProtocol {
         return Just(DDID(from: userIdString)).eraseToAnyPublisher()
     }
     
+    
+    // FIXME: uid to ddid 맵핑 컬랙션을 정의 후 수정해야함.
+    func getMyId(for uid: String) -> AnyPublisher<DDID?, Error> {
+        let conditions = ["uid": uid]
+        
+        return self.firebaseNetworkService.getDocuments(collection: .user, conditions: conditions)
+            .map { data -> DDID? in
+                guard let ddidString = data.first?["ddid"] as? String,
+                      let ddid = DDID(from: ddidString) else { return nil }
+                return ddid
+            }
+            .eraseToAnyPublisher()
+    }
+    
     func setUser(_ user: User) -> AnyPublisher<User, Error> {
         let publisher = self.firebaseNetworkService.setDocument(collection: .user, document: user.id.ddidString, dictionary: user.dictionary)
             return publisher.tryMap { _ in

--- a/Doolda/Doolda/Data/Repositories/UserRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/UserRepository.swift
@@ -67,7 +67,7 @@ class UserRepository: UserRepositoryProtocol {
     func getMyId(for uid: String) -> AnyPublisher<DDID?, Error> {
         let conditions = ["uid": uid]
         
-        return self.firebaseNetworkService.getDocuments(collection: .user, conditions: conditions)
+        return self.firebaseNetworkService.getDocuments(collection: .ddidDictionary, conditions: conditions)
             .map { data -> DDID? in
                 guard let ddidString = data.first?["ddid"] as? String,
                       let ddid = DDID(from: ddidString) else { return nil }

--- a/Doolda/Doolda/Domain/Interfaces/Repositories/UserRepositoryProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/Repositories/UserRepositoryProtocol.swift
@@ -10,9 +10,11 @@ import Foundation
 
 protocol UserRepositoryProtocol {
     func setMyId(_ id: DDID) -> AnyPublisher<DDID, Never>
+    @available(*, deprecated, message: "getMyId(for uid: String) -> AnyPublisher<DDID?, Error>를 사용하세요")
     func setMyId(uid: String, ddid: DDID) -> AnyPublisher<DDID, Error>
     func getMyId() -> AnyPublisher<DDID?, Never>
-
+    func getMyId(for uid: String) -> AnyPublisher<DDID?, Error>
+    
     func setUser(_ user: User) -> AnyPublisher<User, Error>
     func resetUser(_ user: User) -> AnyPublisher<User, Error>
     

--- a/Doolda/Doolda/Domain/Interfaces/UseCases/GetMyIdUseCaseProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/UseCases/GetMyIdUseCaseProtocol.swift
@@ -9,8 +9,8 @@ import Combine
 import Foundation
 
 protocol GetMyIdUseCaseProtocol {
-    // FIXME: Deprecated
+    @available(*, deprecated, message: "getMyId(for uid: String) -> AnyPublisher<DDID?, Never>를 사용하세요")
     func getMyId() -> AnyPublisher<DDID?, Never>
     
-    func getMyId(for uid: String) -> AnyPublisher<DDID?, Never>
+    func getMyId(for uid: String) -> AnyPublisher<DDID?, Error>
 }

--- a/Doolda/Doolda/Domain/UseCases/GetMyIdUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/GetMyIdUseCase.swift
@@ -15,7 +15,6 @@ final class GetMyIdUseCase: GetMyIdUseCaseProtocol {
         self.userRepository = userRepository
     }
     
-    // FIXME: Deprecated
     func getMyId() -> AnyPublisher<DDID?, Never> {
         return userRepository.getMyId()
     }

--- a/Doolda/Doolda/Domain/UseCases/GetMyIdUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/GetMyIdUseCase.swift
@@ -22,8 +22,7 @@ final class GetMyIdUseCase: GetMyIdUseCaseProtocol {
     
     // TODO: [승지] uid로 DDID 가져오도록 바꾸기 (repository도 포함)
     // uid 에 대응되는 DDID를 올리는건 Dozzing이 한다.
-    func getMyId(for uid: String) -> AnyPublisher<DDID?, Never> {
-//        return userRepository.getMyId(for: uid)
-        return Just(nil).eraseToAnyPublisher()
+    func getMyId(for uid: String) -> AnyPublisher<DDID?, Error> {
+        return self.userRepository.getMyId(for: uid)
     }
 }

--- a/Doolda/Doolda/SplashScene/SplashViewModel.swift
+++ b/Doolda/Doolda/SplashScene/SplashViewModel.swift
@@ -70,21 +70,24 @@ final class SplashViewModel: SplashViewModelProtocol {
         }
     }
     
-    private func validateUser(user: FirebaseAuth.User) {
-         self.getMyIdUseCase.getMyId(for: user.uid)
-             .sink { [weak self] ddid in
-                 guard let self = self else { return }
-                 guard let ddid = ddid else { return } // 에러 처리
-                 self.getUserUseCase.getUser(for: ddid)
-                     .sink { completion in
-                         guard case .failure(let error) = completion else { return }
-                         self.error = error
-                     } receiveValue: { [weak self] dooldaUser in
-                         self?.user = dooldaUser
-                         self?.validateUser(with: dooldaUser)
-                     }.store(in: &self.cancellables)
-             }
-             .store(in: &self.cancellables)
+    private func validateUser(user: FirebaseAuth.User) {        
+        self.getMyIdUseCase.getMyId(for: user.uid)
+            .sink { [weak self] completion in
+                guard case .failure(let error) = completion else { return }
+                self?.error = error
+            } receiveValue: { [weak self] ddid in
+                guard let self = self else { return }
+                guard let ddid = ddid else { return } // 에러 처리
+                self.getUserUseCase.getUser(for: ddid)
+                    .sink { completion in
+                        guard case .failure(let error) = completion else { return }
+                        self.error = error
+                    } receiveValue: { [weak self] dooldaUser in
+                        self?.user = dooldaUser
+                        self?.validateUser(with: dooldaUser)
+                    }.store(in: &self.cancellables)
+            }
+            .store(in: &self.cancellables)
      }
     
     private func validateUser(with dooldaUser: User) {


### PR DESCRIPTION
## 이슈 목록
- [ ] #557 

## 특이사항
getMyId를 파이어베이스를 통해 가져오게 되면서 이전과 다르게 에러를 포함하게 됐습니다.
따라서 함수의 정의가 아래와 같이 수정되었고 이를 사용하는 SplashViewModel및 AuthenticationViewModel에 error를 처리하는 코드를 추가했습니다.

- before
`func getMyId() -> AnyPublisher<DDID?, Never>`

- after
`func getMyId(for uid: String) -> AnyPublisher<DDID?, Error>`


## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

