### PR TITLE
Feat/#563 로그아웃 기능 구현

### DIFF
--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -42,6 +42,13 @@ class SettingsViewController: UIViewController {
         button.setTitleColor(.dooldaWarning, for: .normal)
         return button
     }()
+
+    private lazy var logoutButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("로그아웃", for: .normal)
+        button.setTitleColor(.dooldaWarning, for: .normal)
+        return button
+    }()
     
     private lazy var deleteAccountButton: UIButton = {
         let button = UIButton()
@@ -51,7 +58,7 @@ class SettingsViewController: UIViewController {
     }()
     
     private lazy var danzerZoneStack: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [self.unpairButton, self.deleteAccountButton])
+        let stackView = UIStackView(arrangedSubviews: [self.unpairButton, self.logoutButton, self.deleteAccountButton])
         stackView.distribution = .fillEqually
         stackView.axis = .horizontal
         return stackView
@@ -143,11 +150,11 @@ class SettingsViewController: UIViewController {
 
     private func configureFont() {
         self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16)]
-        self.unpairButton.titleLabel?.font = .systemFont(ofSize: 16)
 
         self.settingsSections.enumerated().forEach { index, section in
             guard let header = self.tableView.headerView(forSection: index) as? SettingsTableViewHeader else { return }
             header.font = .systemFont(ofSize: 17)
+            print(UIFont.systemFont(ofSize: 17))
 
             section.settingsOptions.forEach { options in
                 options.cell.font = .systemFont(ofSize: 16)
@@ -155,7 +162,7 @@ class SettingsViewController: UIViewController {
             
             danzerZoneStack.arrangedSubviews.forEach { subview in
                 guard let button = subview as? UIButton else { return }
-                button.titleLabel?.font = .systemFont(ofSize: 16, weight: .heavy)
+                button.titleLabel?.font = .systemFont(ofSize: 16)
             }
         }
     }
@@ -195,7 +202,14 @@ class SettingsViewController: UIViewController {
                 self?.showUnpairAlert()
             }
             .store(in: &self.cancellables)
-        
+
+        self.logoutButton.publisher(for: .touchUpInside)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                // FIXME: - ViewModel 연결 필요
+            }
+            .store(in: &self.cancellables)
+
         self.deleteAccountButton.publisher(for: .touchUpInside)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -206,7 +206,7 @@ class SettingsViewController: UIViewController {
         self.logoutButton.publisher(for: .touchUpInside)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                // FIXME: - ViewModel 연결 필요
+                self?.showLogoutAlert()
             }
             .store(in: &self.cancellables)
 
@@ -243,7 +243,18 @@ class SettingsViewController: UIViewController {
             }
         self.present(alert, animated: true, completion: nil)
     }
-    
+
+    private func showLogoutAlert() {
+        let alert = UIAlertController.selectAlert(
+            title: "로그아웃",
+            message: "정말 로그아웃 하시겠습니까?",
+            leftActionTitle: "취소",
+            rightActionTitle: "확인") { _ in
+                // FIXME: - ViewModel 연결 필요
+            }
+        self.present(alert, animated: true, completion: nil)
+    }
+
     private func showDeleteAcountAlert() {
         let alert = UIAlertController.selectAlert(
             title: "회원 탈퇴",

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -154,7 +154,6 @@ class SettingsViewController: UIViewController {
         self.settingsSections.enumerated().forEach { index, section in
             guard let header = self.tableView.headerView(forSection: index) as? SettingsTableViewHeader else { return }
             header.font = .systemFont(ofSize: 17)
-            print(UIFont.systemFont(ofSize: 17))
 
             section.settingsOptions.forEach { options in
                 options.cell.font = .systemFont(ofSize: 16)

--- a/Doolda/Doolda/SettingsScene/SettingsViewController.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewController.swift
@@ -250,7 +250,7 @@ class SettingsViewController: UIViewController {
             message: "정말 로그아웃 하시겠습니까?",
             leftActionTitle: "취소",
             rightActionTitle: "확인") { _ in
-                // FIXME: - ViewModel 연결 필요
+                self.viewModel.logoutButtonDidTap()
             }
         self.present(alert, animated: true, completion: nil)
     }

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -56,6 +56,7 @@ class SettingsViewCoordinator: BaseCoordinator {
             let pushNotificationStateUseCase = PushNotificationStateUseCase(pushNotificationStateRepository: pushNotificationStateRepository)
             let authenticationUseCase = AuthenticateUseCase()
             let unpairUserUseCase = UnpairUserUseCase(userRepository: userRepository, pairRepository: pairRepository)
+            let authenticateUseCase = AuthenticateUseCase()
             let firebaseMessageUseCase = FirebaseMessageUseCase(
                 fcmTokenRepository: fcmTokenRepository,
                 firebaseMessageRepository: firebaseMessageRepository
@@ -66,7 +67,7 @@ class SettingsViewCoordinator: BaseCoordinator {
                 user: self.user,
                 globalFontUseCase: globalFontUseCase,
                 unpairUserUseCase: unpairUserUseCase,
-                authenticationUseCase: authenticationUseCase,
+                authenticateUseCase: authenticateUseCase,
                 pushNotificationStateUseCase: pushNotificationStateUseCase,
                 firebaseMessageUseCase: firebaseMessageUseCase
             )

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -19,6 +19,7 @@ protocol SettingsViewModelInput {
     func privacyCellDidTap()
     func contributorCellDidTap()
     func unpairButtonDidTap()
+    func logoutButtonDidTap()
     func deleteAccountButtonDidTap()
     func deinitRequested()
 }
@@ -43,7 +44,7 @@ final class SettingsViewModel: SettingsViewModelProtocol {
     private let user: User
     private let globalFontUseCase: GlobalFontUseCaseProtocol
     private let unpairUserUseCase: UnpairUserUseCaseProtocol
-    private let authenticationUseCase: AuthenticateUseCaseProtocol
+    private let authenticateUseCase: AuthenticateUseCaseProtocol
     private let pushNotificationStateUseCase: PushNotificationStateUseCaseProtocol
     private let firebaseMessageUseCase: FirebaseMessageUseCaseProtocol
     
@@ -57,7 +58,7 @@ final class SettingsViewModel: SettingsViewModelProtocol {
         user: User,
         globalFontUseCase: GlobalFontUseCaseProtocol,
         unpairUserUseCase: UnpairUserUseCaseProtocol,
-        authenticationUseCase: AuthenticateUseCaseProtocol,
+        authenticateUseCase: AuthenticateUseCaseProtocol,
         pushNotificationStateUseCase: PushNotificationStateUseCaseProtocol,
         firebaseMessageUseCase: FirebaseMessageUseCaseProtocol
     ) {
@@ -65,7 +66,7 @@ final class SettingsViewModel: SettingsViewModelProtocol {
         self.user = user
         self.globalFontUseCase = globalFontUseCase
         self.unpairUserUseCase = unpairUserUseCase
-        self.authenticationUseCase = authenticationUseCase
+        self.authenticateUseCase = authenticateUseCase
         self.pushNotificationStateUseCase = pushNotificationStateUseCase
         self.firebaseMessageUseCase = firebaseMessageUseCase
     }
@@ -118,6 +119,18 @@ final class SettingsViewModel: SettingsViewModelProtocol {
                 )
             }
             .store(in: &self.cancellables)
+    }
+
+    func logoutButtonDidTap() {
+        do {
+            try self.authenticateUseCase.signOut()
+            NotificationCenter.default.post(
+                name: AppCoordinator.Notifications.appRestartSignal,
+                object: nil
+            )
+        } catch(let error) {
+            self.error = error
+        }
     }
     
     // FIXME: NOT IMPLEMENTED


### PR DESCRIPTION
## 이슈 목록
- [x] #563

## 특이사항
* `SettingsViewModel` 보시면 앱 재시작 시그널을 Notification으로 보내고 있는데, 이것도 combine으로 통일하면 어떨까요?
* 설정 화면에서 폰트 변경시, 하단의 danger zone 버튼 3개의 폰트가 고딕체 같은 이상한 폰트로 변경되는 버그가 있었습니다. 기존에 `SettingsViewController` 에서 `.systemFont(ofSize: 16, weight: .heavy)` 로 폰트를 설정해주고 있었던게 문제였습니다. 도비마요 같은 폰트들은 볼드체가 없기 때문이졍.. 그래서 이 부분 수정해주었숩니다!!


## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

