### PR TITLE
회원탈퇴 및 친구끊기 시 데이터가 삭제 되도록 구현

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 		66CD6456273BB88A00E55C03 /* PhotoFrameCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CD6455273BB88A00E55C03 /* PhotoFrameCollectionViewCell.swift */; };
 		66CD645A273BE5A000E55C03 /* PhotoPickerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CD6459273BE5A000E55C03 /* PhotoPickerCollectionViewCell.swift */; };
 		66CD6464273D125F00E55C03 /* CGImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CD6463273D125E00E55C03 /* CGImage+Extensions.swift */; };
+		66CEFDF3284BB6E800990EBA /* StorageReference+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CEFDF2284BB6E800990EBA /* StorageReference+Extensions.swift */; };
 		66ECCD3A273E5342003990EE /* CarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66ECCD39273E5342003990EE /* CarouselView.swift */; };
 		66ECCD3C273F7C9F003990EE /* CustomActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66ECCD3B273F7C9E003990EE /* CustomActivityIndicator.swift */; };
 		66F1760527548260006ACB41 /* UnpairUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F1760427548260006ACB41 /* UnpairUserUseCase.swift */; };
@@ -605,6 +606,7 @@
 		66CD6455273BB88A00E55C03 /* PhotoFrameCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoFrameCollectionViewCell.swift; sourceTree = "<group>"; };
 		66CD6459273BE5A000E55C03 /* PhotoPickerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerCollectionViewCell.swift; sourceTree = "<group>"; };
 		66CD6463273D125E00E55C03 /* CGImage+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGImage+Extensions.swift"; sourceTree = "<group>"; };
+		66CEFDF2284BB6E800990EBA /* StorageReference+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageReference+Extensions.swift"; sourceTree = "<group>"; };
 		66ECCD39273E5342003990EE /* CarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselView.swift; sourceTree = "<group>"; };
 		66ECCD3B273F7C9E003990EE /* CustomActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActivityIndicator.swift; sourceTree = "<group>"; };
 		66F1760427548260006ACB41 /* UnpairUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnpairUserUseCase.swift; sourceTree = "<group>"; };
@@ -1341,6 +1343,7 @@
 				319C222C273CEFBB009CE65C /* CIImage+Extension.swift */,
 				66CD6463273D125E00E55C03 /* CGImage+Extensions.swift */,
 				1D9DC0A4274B8A890060587B /* Collection+Extensions.swift */,
+				66CEFDF2284BB6E800990EBA /* StorageReference+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2380,6 +2383,7 @@
 				A40AA6A627F369EA00754E4F /* AuthenticationViewCoordinator.swift in Sources */,
 				FCCF022F273A12B400EAB00B /* EditPageViewController.swift in Sources */,
 				6653039B2743B3FF00E3075C /* CoreDataModel.xcdatamodeld in Sources */,
+				66CEFDF3284BB6E800990EBA /* StorageReference+Extensions.swift in Sources */,
 				FCD24D75274392AB000203F7 /* GlobalFontRepositoryProtocol.swift in Sources */,
 				1D6232ED27310EE300A9AD6B /* UIImage+Extensions.swift in Sources */,
 				1D3925D0273C1263003A0B70 /* CGFloat+Extensions.swift in Sources */,

--- a/Doolda/Doolda/Data/Interfaces/FirebaseNetworkServiceProtocol.swift
+++ b/Doolda/Doolda/Data/Interfaces/FirebaseNetworkServiceProtocol.swift
@@ -8,6 +8,8 @@
 import Combine
 import Foundation
 
+import Firebase
+
 protocol FirebaseNetworkServiceProtocol {
     func getDocument(collection: FirebaseCollection, document: String) -> AnyPublisher<[String: Any], Error>
     func setDocument(collection: FirebaseCollection, document: String, dictionary: [String: Any]) -> AnyPublisher<Void, Error>
@@ -16,6 +18,7 @@ protocol FirebaseNetworkServiceProtocol {
     func getDocuments(collection: FirebaseCollection, conditions: [String: Any]?) -> AnyPublisher<[[String: Any]], Error>
     func getDocuments<T: DataTransferable>(collection: FirebaseCollection, conditions: [String: Any]?) -> AnyPublisher<[T], Error>
     func deleteDocument(collection: FirebaseCollection, document: String) -> AnyPublisher<Void, Error>
+    func deleteDocuments(collection: FirebaseCollection, fieldPath: FieldPath, prefix: String) -> AnyPublisher<Void, Error>
     func uploadData(path: String, fileName: String, data: Data) -> AnyPublisher<URL, Error>
     func donwloadData(path: String, fileName: String) -> AnyPublisher<Data, Error>
     func deleteStorageFolder(path: String) -> AnyPublisher<Void, Error>

--- a/Doolda/Doolda/Data/Interfaces/FirebaseNetworkServiceProtocol.swift
+++ b/Doolda/Doolda/Data/Interfaces/FirebaseNetworkServiceProtocol.swift
@@ -18,6 +18,7 @@ protocol FirebaseNetworkServiceProtocol {
     func deleteDocument(collection: FirebaseCollection, document: String) -> AnyPublisher<Void, Error>
     func uploadData(path: String, fileName: String, data: Data) -> AnyPublisher<URL, Error>
     func donwloadData(path: String, fileName: String) -> AnyPublisher<Data, Error>
+    func deleteStorageFolder(path: String) -> AnyPublisher<Void, Error>
 }
 
 protocol DataTransferable {

--- a/Doolda/Doolda/Domain/Interfaces/Repositories/PageRepositoryProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/Repositories/PageRepositoryProtocol.swift
@@ -12,4 +12,5 @@ protocol PageRepositoryProtocol {
     func savePage(_ page: PageEntity) -> AnyPublisher<PageEntity, Error>
     func updatePage(_ page: PageEntity) -> AnyPublisher<PageEntity, Error>
     func fetchPages(for pair: DDID) -> AnyPublisher<[PageEntity], Error>
+    func deletePages(for pair: DDID) -> AnyPublisher<Void, Error>
 }

--- a/Doolda/Doolda/Domain/UseCases/UnpairUserUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/UnpairUserUseCase.swift
@@ -13,35 +13,56 @@ protocol UnpairUserUseCaseProtocol {
 }
 
 final class UnpairUserUseCase: UnpairUserUseCaseProtocol {
+    enum Errors: LocalizedError {
+        case userNotPaired
+        
+        var errorDescription: String? {
+            switch self {
+            case .userNotPaired:
+                return "연결된 친구가 없습니다."
+            }
+        }
+    }
+    
     private let userRepository: UserRepositoryProtocol
     private let pairRepository: PairRepositoryProtocol
+    private let pageRepository: PageRepositoryProtocol
     
-    init(userRepository: UserRepositoryProtocol, pairRepository: PairRepositoryProtocol) {
+    init(
+        userRepository: UserRepositoryProtocol,
+        pairRepository: PairRepositoryProtocol,
+        pageRepository: PageRepositoryProtocol
+    ) {
         self.userRepository = userRepository
         self.pairRepository = pairRepository
+        self.pageRepository = pageRepository
     }
     
     func unpair(user: User) -> AnyPublisher<User, Error> {
+        guard let pairId = user.pairId else { return Fail(error: Errors.userNotPaired).eraseToAnyPublisher() }
+        
         let resetUser = User(id: user.id, pairId: nil, friendId: nil)
         let publisher: AnyPublisher<User, Error>
         
         if let friendId = user.friendId,
            resetUser.id != friendId {
-            publisher = Publishers.Zip3(
+            publisher = Publishers.Zip4(
                 self.userRepository.resetUser(resetUser),
                 self.userRepository.resetUser(User(id: friendId, pairId: nil, friendId: nil)),
-                self.pairRepository.deletePair(with: user)
+                self.pairRepository.deletePair(with: user),
+                self.pageRepository.deletePages(for: pairId)
             )
-                .map { user, _, _ in
+                .map { user, _, _, _ in
                     return user
                 }
                 .eraseToAnyPublisher()
         } else {
-            publisher = Publishers.Zip(
+            publisher = Publishers.Zip3(
                 self.userRepository.resetUser(resetUser),
-                self.pairRepository.deletePair(with: user)
+                self.pairRepository.deletePair(with: user),
+                self.pageRepository.deletePages(for: pairId)
             )
-                .map { user, _ in
+                .map { user, _, _ in
                     return user
                 }
                 .eraseToAnyPublisher()

--- a/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewCoordinator.swift
@@ -49,13 +49,21 @@ class SettingsViewCoordinator: BaseCoordinator {
                 networkService: firebaseNetworkService
             )
             let pairRepository = PairRepository(networkService: firebaseNetworkService)
+            let pageRepository = PageRepository(
+                networkService: firebaseNetworkService,
+                pageEntityPersistenceService: CoreDataPageEntityPersistenceService(coreDataPersistenceService: CoreDataPersistenceService.shared)
+            )
             let fcmTokenRepository = FCMTokenRepository(firebaseNetworkService: firebaseNetworkService)
             let firebaseMessageRepository = FirebaseMessageRepository(urlSessionNetworkService: urlSessionNetworkService)
 
             let globalFontUseCase = GlobalFontUseCase(globalFontRepository: globalFontRepository)
             let pushNotificationStateUseCase = PushNotificationStateUseCase(pushNotificationStateRepository: pushNotificationStateRepository)
             let authenticationUseCase = AuthenticateUseCase()
-            let unpairUserUseCase = UnpairUserUseCase(userRepository: userRepository, pairRepository: pairRepository)
+            let unpairUserUseCase = UnpairUserUseCase(
+                userRepository: userRepository,
+                pairRepository: pairRepository,
+                pageRepository: pageRepository
+            )
             let authenticateUseCase = AuthenticateUseCase()
             let firebaseMessageUseCase = FirebaseMessageUseCase(
                 fcmTokenRepository: fcmTokenRepository,

--- a/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
+++ b/Doolda/Doolda/SettingsScene/SettingsViewModel.swift
@@ -133,20 +133,22 @@ final class SettingsViewModel: SettingsViewModelProtocol {
         }
     }
     
-    // FIXME: NOT IMPLEMENTED
     func deleteAccountButtonDidTap() {
-        self.authenticateUseCase.delete()
+        Publishers.Zip(
+            self.unpairUserUseCase.unpair(user: self.user),
+            self.authenticateUseCase.delete()
+        )
             .sink { [weak self] completion in
-            guard case .failure(let error) = completion else { return }
+                guard case .failure(let error) = completion else { return }
                 try? Auth.auth().signOut()
-            self?.error = error
-        } receiveValue: { _ in
-            NotificationCenter.default.post(
-                name: AppCoordinator.Notifications.appRestartSignal,
-                object: nil
-            )
-        }
-        .store(in: &self.cancellables)
+                self?.error = error
+            } receiveValue: { _ in
+                NotificationCenter.default.post(
+                    name: AppCoordinator.Notifications.appRestartSignal,
+                    object: nil
+                )
+            }
+            .store(in: &self.cancellables)
     }
     
     func deinitRequested() {

--- a/Doolda/Doolda/Support/Extensions/StorageReference+Extensions.swift
+++ b/Doolda/Doolda/Support/Extensions/StorageReference+Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  StorageReference+Extensions.swift
+//  Doolda
+//
+//  Created by 정지승 on 2022/06/05.
+//
+
+import Combine
+import Foundation
+
+import Firebase
+
+extension StorageReference {
+    func delete() -> AnyPublisher<Void, Error> {
+        return Future { [weak self] promise in
+            self?.delete { error in
+                if let error = error { return promise(.failure(error)) }
+                promise(.success(()))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
## 이슈 목록
- [ ] #573 

## 특이사항
* Firebase Page Collection에서 Document Id로 prefix 조회하기 위해 아래와 같은 방법을 사용했는데 더 좋은 방법이 있다면 피드백 부탁드려요

```swift
let query = Firestore.firestore().collection(collection.rawValue)
            .whereField(fieldPath, isGreaterThanOrEqualTo: prefix)
            .whereField(fieldPath, isLessThan: prefix + "z")
```


## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

