### PR TITLE
[bug/#580] 친구 연결 해제 문제 해결

### DIFF
--- a/Doolda/Doolda/Data/Repositories/UserRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/UserRepository.swift
@@ -75,17 +75,6 @@ class UserRepository: UserRepositoryProtocol {
             .eraseToAnyPublisher()
     }
     
-    func resetUser(_ user: User) -> AnyPublisher<User, Error> {
-        let resetedUser = User(id: user.id)
-        let publisher = self.firebaseNetworkService
-            .setDocument(collection: .user, document: user.id.ddidString, dictionary: resetedUser.dictionary)
-
-        return publisher.tryMap { _ in
-            return resetedUser
-        }
-        .eraseToAnyPublisher()
-    }
-    
     func fetchUser(_ id: DDID) -> AnyPublisher<User, Error> {
         let publisher: AnyPublisher<UserDataTransferObject, Error> = self.firebaseNetworkService
             .getDocument(collection: .user, document: id.ddidString)

--- a/Doolda/Doolda/Domain/Entities/User.swift
+++ b/Doolda/Doolda/Domain/Entities/User.swift
@@ -55,4 +55,8 @@ struct User: Hashable {
     func pairedUser(with other: User, as pair: DDID) -> User {
         User(id: id, pairId: pair, friendId: other.id, isAgreed: isAgreed)
     }
+    
+    func unpairedUser() -> User {
+        User(id: id, pairId: nil, friendId: nil, isAgreed: isAgreed)
+    }
 }

--- a/Doolda/Doolda/Domain/Interfaces/Repositories/UserRepositoryProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/Repositories/UserRepositoryProtocol.swift
@@ -14,7 +14,6 @@ protocol UserRepositoryProtocol {
     func getMyId(for uid: String) -> AnyPublisher<DDID?, Error>
     
     func setUser(_ user: User) -> AnyPublisher<User, Error>
-    func resetUser(_ user: User) -> AnyPublisher<User, Error>
     
     func fetchUser(_ id: DDID) -> AnyPublisher<User, Error>
     func fetchUser(_ user: User) -> AnyPublisher<User, Error>


### PR DESCRIPTION
## 이슈 목록
- [x] #580 

## 특이사항
* `User` 에 대한 조작을 너도 나도 하고있는데 `isAgreed` 프로퍼티가 나중에 추가되었기 때문에 이걸 모두가 알잘딱 커버하지 못한게 문제.. 이런식의 common한 조작은 모두 `User` 내에 정의된 메서드를 이용하도록 했음.
* `resetUser(_:)` 는 사실 필요가 없다. 왜냐면 `User` 를 변형시켜서 `setUser(_:)` 하면 되니까.. 네.. 없앴습니다.
* 위 두개를 적당히 섞어준 결과 데이터 누락(이 경우는 `isAgreed` 정보) 없이 친구 연결해제가 잘 이뤄지게 됐고 덕분에 연결 해제하면 친구연결화면으로 잘 보내집니다!

## 결과!

| 13 mini | 13 Pro |
|:--:|:--:|
| ![13mini](https://user-images.githubusercontent.com/20262392/173846947-affd97c1-a88f-47ba-8d6f-3614e6c5eb43.gif) | ![13pro](https://user-images.githubusercontent.com/20262392/173846974-b56b452f-9870-4c0d-9c87-f2662b1c5f8c.gif) |