### PR TITLE
(#598) 🚨: 스티커팩 바텀시트의 page indicator가 정상적으로 동작되지 않는 현상 수정

### DIFF
--- a/Doolda/Doolda/EditPageScene/StickerPickerScene/StickerPickerBottomSheetViewController.swift
+++ b/Doolda/Doolda/EditPageScene/StickerPickerScene/StickerPickerBottomSheetViewController.swift
@@ -238,8 +238,9 @@ extension StickerPickerBottomSheetViewController: UICollectionViewDelegate {
         self.dismiss(animated: true, completion: nil)
     }
     
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard let currentSection = self.stickerPickerView.collectionView.indexPathsForVisibleItems.first?.section else { return }
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        guard let collectionView = scrollView as? UICollectionView else { return }
+        let currentSection = Int(round(CGFloat(collectionView.numberOfSections) * targetContentOffset.pointee.x / scrollView.contentSize.width))
         self.stickerPickerView.currentPack = currentSection
     }
 }

--- a/Doolda/Doolda/EditPageScene/StickerPickerScene/StickerPickerBottomSheetViewController.swift
+++ b/Doolda/Doolda/EditPageScene/StickerPickerScene/StickerPickerBottomSheetViewController.swift
@@ -220,8 +220,6 @@ class StickerPickerBottomSheetViewController: BottomSheetViewController {
 
 extension StickerPickerBottomSheetViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        self.stickerPickerView.currentPack = indexPath.section
-
         guard let cell = cell as? PackedStickerCollectionViewCell,
               let operationQueue = OperationQueue.current,
               let stickerPack = self.viewModel.getStickerPackEntity(at: indexPath.section) else { return }
@@ -238,6 +236,11 @@ extension StickerPickerBottomSheetViewController: UICollectionViewDelegate {
               let stickerComponentEntity = self.viewModel.stickerDidSelect(at: indexPath) else { return }
         self.delegate?.stickerDidSelected(stickerComponentEntity)
         self.dismiss(animated: true, completion: nil)
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard let currentSection = self.stickerPickerView.collectionView.indexPathsForVisibleItems.first?.section else { return }
+        self.stickerPickerView.currentPack = currentSection
     }
 }
 

--- a/Doolda/Doolda/EditPageScene/StickerPickerScene/StickerPickerView.swift
+++ b/Doolda/Doolda/EditPageScene/StickerPickerScene/StickerPickerView.swift
@@ -88,5 +88,14 @@ class StickerPickerView: UIView {
                 self.pageControl.currentPage = index
             }
             .store(in: &self.cancellables)
+        
+        self.pageControl.publisher(for: .valueChanged)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                let currentPage = self.pageControl.currentPage
+                self.collectionView.scrollToItem(at: IndexPath(item: 0, section: currentPage), at: .centeredHorizontally, animated: true)
+            }
+            .store(in: &self.cancellables)
     }
 }

--- a/Doolda/Doolda/EditPageScene/StickerPickerScene/StickerPickerView.swift
+++ b/Doolda/Doolda/EditPageScene/StickerPickerScene/StickerPickerView.swift
@@ -78,16 +78,15 @@ class StickerPickerView: UIView {
 
         self.pageControl.numberOfPages = self.collectionView.dataSource?.numberOfSections?(in: self.collectionView) ?? 0
         self.pageControl.currentPage = 0
-
     }
 
     private func bindUI() {
         self.$currentPack
+            .removeDuplicates()
             .sink { [weak self] index in
                 guard let self = self else { return }
                 self.pageControl.currentPage = index
             }
             .store(in: &self.cancellables)
     }
-
 }


### PR DESCRIPTION
## 이슈 목록
- [ ] #598 

## 특이사항

#598 버그가 발생한 원인은 UICollectionViewDelegate의 `willDisplay` 에서 드래그 후 화면에 보일 스티커팩을 선택했기 때문입니다.

해당 delegate는 CollectionView에서 다음 보일 셀이 나타나기전에 호출되는데, 이 시점은 드래그가 끝나는 시점을 의미하지 않습니다. 

`func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath)` 

~~이를 해결하기 위해 현재 보이는 셀들 중 첫번째 셀의 index로 currentPack을 선택하게 하도록 했는데 아래 첨부한 gif처럼 왼쪽에서 오른쪽으로 스와이프 할 때, 오른쪽에서 왼쪽으로 스와이프 할 때 page indicator가 이동되는 타이밍이 달라져서 보기에 별로 좋은거 같지 않습니다 🥲~~

~~현재 스티커팩을 선택하기 위해 좋은 방법이 있을까요??~~

드래그가 끝나는 시점에 현재 스티커팩의 index를 결정하도록 수정했습니다.

<img width="300" alt="gif" src="https://user-images.githubusercontent.com/49086747/176184542-0f56011f-e1a0-424a-8c43-ace2215f92a2.gif">


## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

