### PR TITLE
(#588) 🚨: 다이어리 필터 수정시 다이어리 캐러셀뷰 레이아웃이 올바르게 나타나지 않는 현상 수정

### DIFF
--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -283,7 +283,7 @@ class DiaryViewController: UIViewController {
             self.pageCollectionView.showsVerticalScrollIndicator = false
             self.navigationController?.hidesBarsOnSwipe = false
             self.navigationController?.isNavigationBarHidden = false
-            self.scrollToPage(of: Int(self.pageCollectionView.contentOffset.x / self.pageOffset))
+            self.scrollToPage(of: self.viewModel.lastDisplayedPage)
         }
     }
     

--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -163,8 +163,8 @@ class DiaryViewController: UIViewController {
         self.viewModel.filteredPageEntitiesPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] entities in
-                self?.applySnapshot(pageEntities: entities)
-                self?.scrollToPage(of: min(self?.viewModel.currentPage ?? 0, entities.count))
+                self?.applySnapshot(pageEntities: entities, withAnimation: self?.viewModel.displayMode == .list)
+                self?.scrollToPage(of: min(self?.viewModel.lastDisplayedPage ?? 0, entities.count))
             }
             .store(in: &self.cancellables)
 
@@ -336,7 +336,7 @@ extension DiaryViewController: UICollectionViewDelegateFlowLayout {
             actualIndex = Int(round(estimatedIndex))
         }
         
-        self.viewModel.changePage(to: actualIndex)
+        self.viewModel.changeDisplayedPage(to: actualIndex)
         
         self.setTitle(for: actualIndex - 1)
         targetContentOffset.pointee = CGPoint(x: CGFloat(actualIndex) * pageOffset - 16, y: 0)

--- a/Doolda/Doolda/DiaryScene/DiaryViewController.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewController.swift
@@ -164,6 +164,7 @@ class DiaryViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] entities in
                 self?.applySnapshot(pageEntities: entities)
+                self?.scrollToPage(of: min(self?.viewModel.currentPage ?? 0, entities.count))
             }
             .store(in: &self.cancellables)
 
@@ -334,6 +335,8 @@ extension DiaryViewController: UICollectionViewDelegateFlowLayout {
         } else {
             actualIndex = Int(round(estimatedIndex))
         }
+        
+        self.viewModel.changePage(to: actualIndex)
         
         self.setTitle(for: actualIndex - 1)
         targetContentOffset.pointee = CGPoint(x: CGFloat(actualIndex) * pageOffset - 16, y: 0)

--- a/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
@@ -15,6 +15,7 @@ protocol DiaryViewModelInput {
     func settingsButtonDidTap()
     func addPageButtonDidTap()
     func refreshButtonDidTap()
+    func changePage(to index: Int)
     func filterDidApply(author: DiaryAuthorFilter, orderBy: DiaryOrderFilter)
     func filterOptionDidChange(author: DiaryAuthorFilter, orderBy: DiaryOrderFilter)
     func filterBottomSheetDidDismiss()
@@ -32,6 +33,7 @@ protocol DiaryViewModelOutput {
     var isRefreshingPublisher: AnyPublisher<Bool, Never> { get }
     var displayMode: DiaryDisplayMode { get }
     var filteredEntityCount: Int { get }
+    var currentPage: Int { get }
 }
 
 typealias DiaryViewModelProtocol = DiaryViewModelInput & DiaryViewModelOutput
@@ -101,6 +103,7 @@ final class DiaryViewModel: DiaryViewModelProtocol {
     var settingsPageRequested = PassthroughSubject<Void, Never>()
     var pageDetailRequested = PassthroughSubject<PageEntity, Never>()
     var filteringSheetRequested = PassthroughSubject<(DiaryAuthorFilter, DiaryOrderFilter), Never>()
+    var currentPage: Int = 0
     
     @Published var displayMode: DiaryDisplayMode = .carousel
     @Published private var error: Error?
@@ -112,7 +115,6 @@ final class DiaryViewModel: DiaryViewModelProtocol {
     @Published private var orderFilter: DiaryOrderFilter = .descending
     
     private var cancellables: Set<AnyCancellable> = []
-    
     private let sceneId: UUID
     private let user: User
     private let checkMyTurnUseCase: CheckMyTurnUseCaseProtocol
@@ -189,6 +191,10 @@ final class DiaryViewModel: DiaryViewModelProtocol {
     
     func filterButtonDidTap() {
         self.filteringSheetRequested.send((self.authorFilter, self.orderFilter))
+    }
+    
+    func changePage(to index: Int) {
+        self.currentPage = index
     }
     
     func filterDidApply(author: DiaryAuthorFilter, orderBy: DiaryOrderFilter) {

--- a/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
@@ -170,6 +170,7 @@ final class DiaryViewModel: DiaryViewModelProtocol {
     
     func pageDidTap(index: Int) {
         let selectedPageEntity = self.filteredPageEntities[index]
+        self.lastDisplayedPage = index + 1
         self.pageDetailRequested.send(selectedPageEntity)
     }
 

--- a/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewModel.swift
@@ -15,7 +15,7 @@ protocol DiaryViewModelInput {
     func settingsButtonDidTap()
     func addPageButtonDidTap()
     func refreshButtonDidTap()
-    func changePage(to index: Int)
+    func changeDisplayedPage(to index: Int)
     func filterDidApply(author: DiaryAuthorFilter, orderBy: DiaryOrderFilter)
     func filterOptionDidChange(author: DiaryAuthorFilter, orderBy: DiaryOrderFilter)
     func filterBottomSheetDidDismiss()
@@ -33,7 +33,7 @@ protocol DiaryViewModelOutput {
     var isRefreshingPublisher: AnyPublisher<Bool, Never> { get }
     var displayMode: DiaryDisplayMode { get }
     var filteredEntityCount: Int { get }
-    var currentPage: Int { get }
+    var lastDisplayedPage: Int { get }
 }
 
 typealias DiaryViewModelProtocol = DiaryViewModelInput & DiaryViewModelOutput
@@ -103,7 +103,7 @@ final class DiaryViewModel: DiaryViewModelProtocol {
     var settingsPageRequested = PassthroughSubject<Void, Never>()
     var pageDetailRequested = PassthroughSubject<PageEntity, Never>()
     var filteringSheetRequested = PassthroughSubject<(DiaryAuthorFilter, DiaryOrderFilter), Never>()
-    var currentPage: Int = 0
+    var lastDisplayedPage: Int = 0
     
     @Published var displayMode: DiaryDisplayMode = .carousel
     @Published private var error: Error?
@@ -193,8 +193,8 @@ final class DiaryViewModel: DiaryViewModelProtocol {
         self.filteringSheetRequested.send((self.authorFilter, self.orderFilter))
     }
     
-    func changePage(to index: Int) {
-        self.currentPage = index
+    func changeDisplayedPage(to index: Int) {
+        self.lastDisplayedPage = index
     }
     
     func filterDidApply(author: DiaryAuthorFilter, orderBy: DiaryOrderFilter) {


### PR DESCRIPTION
## 이슈 목록
- [ ] #588 
- [ ] #624

## 특이사항

다이어리 필터링 시 캐러셀뷰 레이아웃이 올바르게 나타나지 않는 현상을 제거했습니다.
기존 코드에서는 드래그가 끝나는 시점에 `targetContentOffset.pointee` 의 offset을 조절하는 방법으로 캐러셀을 구현했는데
필터링을 할때는 offset을 조절하지 않아 문제가 발생한것으로 파악됩니다.

스크롤을 할때 마지막으로 봤던 페이지의 index를 기록하고,
CollectionView의 DataSource가 변경될 때 스크롤을 조절함으로 이를 해결했습니다.

스크롤을 조절할때 사용한 식은 아래와 같습니다.
`self?.scrollToPage(of: min(self?.viewModel.lastDisplayedPage ?? 0, entities.count))`

다이어리 필터링 중 마지막으로 봤던 페이지의 index가 필터링된 페이지의 개수보다 보다 작아지면 필터링된 페이지 중 마지막 페이지를 보게됩니다.
필터를 적용하지 않고 바텀 시트를 내리게 되면 마지막으로 봤던 페이지가 다시 화면에 나타납니다.

더 좋은 스크롤 방법이 있다면 조언 부탁드려요

| as-is | to-be |
|---|---|
| <img width="300" alt="gif" src="https://user-images.githubusercontent.com/49086747/174848501-4aa4f692-a69c-4ecc-b26f-133ed57f1c52.gif"> | <img width="300" alt="gif" src="https://user-images.githubusercontent.com/49086747/176702456-74493299-a75b-48d6-9bdb-cd2613f72444.gif"> |

추가적으로 캐러셀 화면에서 필터링시 CollectionView에 애니메이션이 동작되면 보기 불편한것 같아 캐러셀뷰 모드에선 애니메이션이 동작되지 않도록 수정했습니다.
요거도 기존게 더 보기 좋으시면 피드백 남겨주세용

| as-is | to-be |
|---|---|
| <img width="300" alt="gif" src="https://user-images.githubusercontent.com/49086747/176703791-f9746543-1f01-4da0-82d7-30f011a57df3.gif">  | <img width="300" alt="gif" src="https://user-images.githubusercontent.com/49086747/176703972-8790e513-88da-43f3-bee5-b5baaa87d6a5.gif">  |



## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

