### PR TITLE
(#600) 🚨: 다이어리 페이지 저장 중 저장/나가기 버튼에 접근이 가능한 문제 수정

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 		A40AA6A027F35C0C00754E4F /* AuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40AA69F27F35C0C00754E4F /* AuthenticationViewController.swift */; };
 		A40AA6A227F362A100754E4F /* AuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40AA6A127F362A100754E4F /* AuthenticationViewModel.swift */; };
 		A40AA6A627F369EA00754E4F /* AuthenticationViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40AA6A527F369EA00754E4F /* AuthenticationViewCoordinator.swift */; };
+		CE57C3352868369600F7EB5D /* UIApplication+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE57C3342868369600F7EB5D /* UIApplication+Extensions.swift */; };
 		CE5E2A88285D7E4A00A91F22 /* DeviceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5E2A86285D7E4A00A91F22 /* DeviceUseCase.swift */; };
 		CE5E2A89285D7E4A00A91F22 /* UserStateObservingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5E2A87285D7E4A00A91F22 /* UserStateObservingUseCase.swift */; };
 		CE5E2A8B285D7E5900A91F22 /* LoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5E2A8A285D7E5900A91F22 /* LoginRepository.swift */; };
@@ -629,6 +630,7 @@
 		A40AA69F27F35C0C00754E4F /* AuthenticationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewController.swift; sourceTree = "<group>"; };
 		A40AA6A127F362A100754E4F /* AuthenticationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewModel.swift; sourceTree = "<group>"; };
 		A40AA6A527F369EA00754E4F /* AuthenticationViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewCoordinator.swift; sourceTree = "<group>"; };
+		CE57C3342868369600F7EB5D /* UIApplication+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extensions.swift"; sourceTree = "<group>"; };
 		CE5E2A86285D7E4A00A91F22 /* DeviceUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceUseCase.swift; sourceTree = "<group>"; };
 		CE5E2A87285D7E4A00A91F22 /* UserStateObservingUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserStateObservingUseCase.swift; sourceTree = "<group>"; };
 		CE5E2A8A285D7E5900A91F22 /* LoginRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginRepository.swift; sourceTree = "<group>"; };
@@ -1337,6 +1339,7 @@
 				66CD6463273D125E00E55C03 /* CGImage+Extensions.swift */,
 				1D9DC0A4274B8A890060587B /* Collection+Extensions.swift */,
 				66CEFDF2284BB6E800990EBA /* StorageReference+Extensions.swift */,
+				CE57C3342868369600F7EB5D /* UIApplication+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2416,6 +2419,7 @@
 				66F1760527548260006ACB41 /* UnpairUserUseCase.swift in Sources */,
 				CEA7D295285D7CDD00AD7D00 /* DooldaButton.swift in Sources */,
 				FCD24D7127437F31000203F7 /* UIFont+Extensions.swift in Sources */,
+				CE57C3352868369600F7EB5D /* UIApplication+Extensions.swift in Sources */,
 				1DBAA7F327E6B64200956C82 /* FCMToken.swift in Sources */,
 				318D9F70274E12D900AA6F0E /* PageDetailViewModel.swift in Sources */,
 				66F176152754C413006ACB41 /* ImageComposeUseCaseProtocol.swift in Sources */,

--- a/Doolda/Doolda/EditPageScene/EditPageViewController.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewController.swift
@@ -191,8 +191,8 @@ class EditPageViewController: UIViewController {
             make.top.equalTo(self.pageView.snp.bottom).offset(5)
             make.width.equalTo(135)
         }
-        
-        self.view.addSubview(self.activityIndicator)
+
+        UIApplication.shared.currentWindow?.addSubview(self.activityIndicator)
         self.activityIndicator.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
@@ -389,6 +389,12 @@ class EditPageViewController: UIViewController {
                 self?.present(alert, animated: true, completion: nil)
             }
             .store(in: &self.cancellables)
+
+        self.viewModel?.editPageSavedPublisher
+            .sink { [weak self] _ in
+                self?.activityIndicator.stopAnimating()
+            }
+            .store(in: &cancellables)
     }
     
     // MARK: - Private Methods

--- a/Doolda/Doolda/EditPageScene/EditPageViewModel.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewModel.swift
@@ -40,6 +40,7 @@ protocol EditPageViewModelOutput {
     var selectedComponentPublisher: AnyPublisher<ComponentEntity?, Never> { get }
     var componentsPublisher: AnyPublisher<[ComponentEntity], Never> { get }
     var backgroundPublisher: AnyPublisher<BackgroundType, Never> { get }
+    var editPageSavedPublisher: AnyPublisher<Void, Never> { get }
     var errorPublisher: AnyPublisher<Error?, Never> { get }
 }
 
@@ -50,6 +51,7 @@ final class EditPageViewModel: EditPageViewModelProtocol {
     var componentsPublisher: AnyPublisher<[ComponentEntity], Never> { self.$components.eraseToAnyPublisher() }
     var backgroundPublisher: AnyPublisher<BackgroundType, Never> { self.$background.eraseToAnyPublisher() }
     var errorPublisher: AnyPublisher<Error?, Never> { self.$error.eraseToAnyPublisher() }
+    var editPageSavedPublisher: AnyPublisher<Void, Never> { self.editPageSaved.eraseToAnyPublisher() }
     
     var editPageSaved = PassthroughSubject<Void, Never>()
     var editPageCanceled = PassthroughSubject<Void, Never>()

--- a/Doolda/Doolda/Support/Extensions/UIApplication+Extensions.swift
+++ b/Doolda/Doolda/Support/Extensions/UIApplication+Extensions.swift
@@ -1,0 +1,17 @@
+//
+//  UIApplication+Extensions.swift
+//  Doolda
+//
+//  Created by USER on 2022/06/26.
+//
+
+import UIKit
+
+extension UIApplication {
+    var currentWindow: UIWindow? {
+        self.connectedScenes
+            .filter {$0.activationState == .foregroundActive}
+            .compactMap { $0 as? UIWindowScene }.first?.windows
+            .filter {$0.isKeyWindow}.first
+    }
+}


### PR DESCRIPTION
## 이슈 목록
- [x] #600 

## 특이사항
* `CustomActivityIndicator` 와 같이 모든 뷰를 덮어야 하는 경우는 현재 뷰에 `addSubview(_:)` 하는 대신 `UIWindow.shared.currentWindow` 에 해주면 화면 전체를 가릴 수 있습니다.

| as-is | to-be |
|:-:|:-:|
| <img width="549" alt="스크린샷 2022-06-26 오후 6 24 46" src="https://user-images.githubusercontent.com/20262392/175808038-6ec01763-23f9-4aa0-b6f1-f729e0dc17db.png"> | <img width="472" alt="스크린샷 2022-06-26 오후 6 23 49" src="https://user-images.githubusercontent.com/20262392/175808084-228ddd7e-ca82-477a-9372-1d69edc08cd0.png"> |


