### PR TITLE
(#601)  TimeOut 에러 추가, 에러에 사유 표시 기능 구현

### DIFF
--- a/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
@@ -107,6 +107,7 @@ final class EditPageViewCoordinator: BaseCoordinator {
             )
             
             editPageViewModel.editPageSaved
+                .receive(on: DispatchQueue.main)
                 .sink { [weak self] _ in
                     self?.editingPageSaved()
                 }

--- a/Doolda/Doolda/Service/Networks/URLSessionNetworkService.swift
+++ b/Doolda/Doolda/Service/Networks/URLSessionNetworkService.swift
@@ -11,19 +11,22 @@ import Accelerate
 
 final class URLSessionNetworkService: URLSessionNetworkServiceProtocol {
     enum Errors: LocalizedError {
-         case invalidUrl
-         
-         var errorDescription: String? {
-             switch self {
-             case .invalidUrl:
-                 return "유효하지 않은 URL입니다."
-             }
-         }
-     }
+        case invalidUrl
+        case requestTimeOut
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidUrl: return "유효하지 않은 URL"
+            case .requestTimeOut: return "요청 시간 초과"
+            }
+        }
+    }
     
     static let shared: URLSessionNetworkService = URLSessionNetworkService()
+    static let timeOutLimit: Int = 60
     
     private let session: URLSession = .shared
+    private let scheduler = DispatchQueue.global()
     private let decoder: JSONDecoder = JSONDecoder()
     
     // MARK: - Initializers
@@ -44,6 +47,7 @@ final class URLSessionNetworkService: URLSessionNetworkServiceProtocol {
                 }
                 return data
             }
+            .timeout(.seconds(Self.timeOutLimit), scheduler: scheduler, customError: { Errors.requestTimeOut })
             .eraseToAnyPublisher()
     }
     


### PR DESCRIPTION
## 이슈 목록
- [x] #601 

## 특이사항
| Service에러(시스템관점) | UseCase에러(사용자관점) Service에러(시스템관점) |
|:-:|:-:|
| <img width="350" src="https://user-images.githubusercontent.com/20262392/175811827-1548b83c-fa70-4328-9042-dc2c27289521.gif"> | <img width="350" src="https://user-images.githubusercontent.com/20262392/175811716-158c701d-7dcc-40aa-bf8b-231456e6336e.gif"> |


* 7b15328 이 커밋에서 한 에러(UseCase 에러)가 다른 에러(Repository or Service 에러)를 사유로 표시할 수 있도록 해봤는데, 다른 에러처리에서도 활용하면 매우매우매우매우매우 좋을 것 같습니다. 기존 에러는 사용자 관점 에러만 보여진거라서 약간 불편했습니다.
* 연결성 확인을 매번 해줘야하나 고민했는데 오히려 사용자 경험에 악영향을 끼칠 것 같기도 해서 (어짜피 앱 시작할 때 유저 정보 가져오는 게 제일 크리티컬하지 그 이후로는 뭐 하려해도 어짜피 네트워크때문에 안될테니까) 포기했는데 어떻게 생각하시나요.

