### PR TITLE
(#589) 🚨: 페이지 재편집시 컴포넌트 선택되지 않도록 변경

### DIFF
--- a/Doolda/Doolda/Domain/Interfaces/UseCases/EditPageUseCaseProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/UseCases/EditPageUseCaseProtocol.swift
@@ -22,7 +22,7 @@ protocol EditPageUseCaseProtocol {
     func bringComponentFront()
     func sendComponentBack()
     func removeComponent()
-    func addComponent(_ component: ComponentEntity)
+    func addComponent(_ component: ComponentEntity, withSelection: Bool)
     
     func changeTextComponent(into content: TextComponentEntity)
     

--- a/Doolda/Doolda/Domain/UseCases/EditPageUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/EditPageUseCase.swift
@@ -108,10 +108,13 @@ final class EditPageUseCase: EditPageUseCaseProtocol {
         self.selectedComponent = self.selectedComponent
     }
 
-    func addComponent(_ component: ComponentEntity) {
+    func addComponent(
+        _ component: ComponentEntity,
+        withSelection: Bool = true
+    ) {
         self.rawPage?.append(component: component)
         self.selectedComponent = component
-        self.selectedComponent = self.selectedComponent
+        self.selectedComponent = withSelection ? self.selectedComponent : nil
     }
     
     func changeTextComponent(into content: TextComponentEntity) {

--- a/Doolda/Doolda/EditPageScene/EditPageViewModel.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewModel.swift
@@ -184,7 +184,7 @@ final class EditPageViewModel: EditPageViewModelProtocol {
     }
     
     func componentEntityDidAdd(_ component: ComponentEntity) {
-        self.editPageUseCase.addComponent(component)
+        self.editPageUseCase.addComponent(component, withSelection: false)
     }
     
     func backgroundColorDidChange(_ backgroundColor: BackgroundType) {


### PR DESCRIPTION
## 이슈 목록
- [x] #589 

| as-is | to-be |
|:-:|:-:|
| <img width="350" src="https://user-images.githubusercontent.com/20262392/175946434-de1cb8bc-4a72-4a19-89ca-b97398c27412.gif"> | <img width="350" src="https://user-images.githubusercontent.com/20262392/175946245-aef3f505-ee09-4761-9ac6-159dc491c830.gif"> |

## 특이사항
* 작성된 페이지를 재편집 할 때에는 가장 아랫단에 깔린 컴포넌부터 위로 올라오며 하나씩 추가(당연하게도 그래야 위에게 아래거 위에 표시되니까)하게되는데, 이 과정에서 `EditPageUseCase` 의 함수를 이용하고 있었습니다. 근데 이 녀석은 컴포넌트를 추가할 때 마다 해당 호출로 추가되는 녀석을 선택된 녀석으로 갱신해주고 있었기 때문에 항상 재편집 시 가장 위에 표시되는 컴포넌트가 선택된 녀석으로 보여지고 있었네요. 

