### PR TITLE
(#590) 회원가입 비밀번호 검증 로직 추가

### DIFF
--- a/Doolda/Doolda/SignUpScene/SignUpViewController.swift
+++ b/Doolda/Doolda/SignUpScene/SignUpViewController.swift
@@ -320,7 +320,7 @@ final class SignUpViewController: UIViewController {
             .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isValid in
-                self?.passwordStateLabel.text = isValid ? "" : "비밀번호 형식이 올바르지 않습니다."
+                self?.passwordStateLabel.text = isValid ? "" : "비밀번호는 영문, 숫자를 조합하여 8자 이상이어야 합니다."
             }
             .store(in: &self.cancellables)
 

--- a/Doolda/Doolda/SignUpScene/SignUpViewController.swift
+++ b/Doolda/Doolda/SignUpScene/SignUpViewController.swift
@@ -319,8 +319,14 @@ final class SignUpViewController: UIViewController {
         viewModel.isPasswordValidPublisher
             .dropFirst()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] isValid in
-                self?.passwordStateLabel.text = isValid ? "" : "비밀번호는 영문, 숫자를 조합하여 8자 이상이어야 합니다."
+            .sink { [weak self] passwordValid in
+                var passwordText = ""
+                switch passwordValid {
+                case .weakPassword:  passwordText = "비밀번호는 영문, 숫자를 조합하여 8자 이상이어야 합니다."
+                case .invalidSymbol: passwordText = "특수문자는 ~,!,@,#,$,%,^,&,* 만 사용가능합니다."
+                case .isValid: passwordText = ""
+                }
+                self?.passwordStateLabel.text = passwordText
             }
             .store(in: &self.cancellables)
 

--- a/Doolda/Doolda/SignUpScene/SignUpViewModel.swift
+++ b/Doolda/Doolda/SignUpScene/SignUpViewModel.swift
@@ -137,8 +137,8 @@ final class SignUpViewModel: SignUpViewModelProtocol {
     }
 
     private func validatePassword(_ password: String) -> Bool {
-        // FIXME: 패스워드 검증을 위한 조건도 추가되어야 함
-        return !password.isEmpty && true
+        let pattern = "(?=.*[a-zA-Z])(?=.*[0-9])[\\w~!@#\\$%\\^&\\*]{8,}"
+        return NSPredicate(format: "SELF MATCHES %@", pattern).evaluate(with: password)
     }
 
     private func validatePasswordCheck(password: String, passwordCheck: String) -> Bool {

--- a/Doolda/Doolda/SignUpScene/SignUpViewModel.swift
+++ b/Doolda/Doolda/SignUpScene/SignUpViewModel.swift
@@ -32,12 +32,14 @@ typealias SignUpViewModelProtocol = SignUpViewModelInput & SignUpViewModelOutput
 enum SignUpError: LocalizedError {
     case invalidEmail
     case emailAlreadyInUse
+    case weakPassword
     case invalidError
 
     var errorDescription: String? {
         switch self {
         case .invalidEmail: return "유효하지 않은 이메일입니다."
         case .emailAlreadyInUse: return "이미 사용하고 있는 이메일입니다."
+        case .weakPassword: return "비밀번호는 영문, 숫자를 조합하여 8자리 이상이어야 합니다."
         case .invalidError: return "에러가 발생했습니다. 다시 시도해 주십시오."
         }
     }
@@ -91,6 +93,8 @@ final class SignUpViewModel: SignUpViewModelProtocol {
                         self?.error = SignUpError.invalidEmail
                     case .emailAlreadyInUse:
                         self?.error = SignUpError.emailAlreadyInUse
+                    case .weakPassword:
+                        self?.error = SignUpError.weakPassword
                     default:
                         self?.error = SignUpError.invalidError
                     }


### PR DESCRIPTION
## 이슈 목록
- [x] #590  

## 특이사항
* 비밀번호 조건을 영문, 숫자를 조합하여 최소 8자 이상으로 했습니다. (이게 흔하고 무난한것 같아서) 특문은 자유이지만 ~!@#$%^&* 만 사용 가능합니다.
* 사용가능한 특수문자에 제한이 있는데 이를 어떻게 안내하면 좋을까요? 일단 다음 스크린샷과 같이 문구를 띄우고 있습니다. 여기서 더 길어지면 구구절절일것 같아서 고민되네요....

![Simulator Screen Shot - iPhone 13 - 2022-06-27 at 23 41 12](https://user-images.githubusercontent.com/61934702/175968327-8164f768-e935-46cb-a29c-b0336d3700cc.PNG)

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

