### PR TITLE
Bug/#602 페이지 저장 실패시 무한로딩 페이지 발생 이슈

### DIFF
--- a/Doolda/Doolda/Data/Interfaces/FirebaseNetworkServiceProtocol.swift
+++ b/Doolda/Doolda/Data/Interfaces/FirebaseNetworkServiceProtocol.swift
@@ -22,6 +22,8 @@ protocol FirebaseNetworkServiceProtocol {
     func uploadData(path: String, fileName: String, data: Data) -> AnyPublisher<URL, Error>
     func donwloadData(path: String, fileName: String) -> AnyPublisher<Data, Error>
     func deleteStorageFolder(path: String) -> AnyPublisher<Void, Error>
+    func deleteStorageFile(path: String, fileName: String) -> AnyPublisher<Void, Error>
+    func deleteStorageFile(for url: URL) -> AnyPublisher<Void, Error>
     func observeDocument(collection: FirebaseCollection, document: String) -> AnyPublisher<[String: Any], Error>
     func observeDocument<T: DataTransferable>(collection: FirebaseCollection, document: String) -> AnyPublisher<T, Error>
 }

--- a/Doolda/Doolda/Data/Repositories/ImageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/ImageRepository.swift
@@ -42,8 +42,8 @@ class ImageRepository: ImageRepositoryProtocol {
         return self.firebaseNetworkService.uploadData(path: pairId.ddidString, fileName: fileName, data: imageData)
     }
     
-    func deleteRemote() {
-        
+    func deleteRemote(with url: URL) -> AnyPublisher<Void, Error> {
+        return self.firebaseNetworkService.deleteStorageFile(for: url)
     }
 
 }

--- a/Doolda/Doolda/Data/Repositories/PageRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/PageRepository.swift
@@ -141,6 +141,13 @@ class PageRepository: PageRepositoryProtocol {
         .eraseToAnyPublisher()
     }
     
+    func deletePage(for page: PageEntity) -> AnyPublisher<Void, Error> {
+        guard let pairId = page.author.pairId?.ddidString else {
+            return Fail(error: PageRepositoryError.failedToDeletePage).eraseToAnyPublisher()
+        }
+        return self.firebaseNetworkService.deleteDocument(collection: .page, document: pairId + page.jsonPath)
+    }
+    
     private func savePageToCache(pages: [PageEntity]) -> AnyPublisher<Void, Error> {
         let savePublishers = pages.map { self.pageEntityPersistenceService.savePageEntity($0) }
         

--- a/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
+++ b/Doolda/Doolda/DiaryScene/DiaryViewCoordinator.swift
@@ -54,7 +54,7 @@ final class DiaryViewCoordinator: BaseCoordinator {
         
         let checkMyTurnUseCase = CheckMyTurnUseCase(pairRepository: pairRepository)
         let getPageUseCase = GetPageUseCase(pageRepository: pageRepository)
-        let getRawPageUseCase = GetRawPageUseCase(rawPageRepository: rawPageRepository)
+        let getRawPageUseCase = GetRawPageUseCase(rawPageRepository: rawPageRepository, pageRepository: pageRepository)
         let firebaseMessageUseCase = FirebaseMessageUseCase.default
         
         let viewModel = DiaryViewModel(

--- a/Doolda/Doolda/Domain/Interfaces/Repositories/ImageRepositoryProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/Repositories/ImageRepositoryProtocol.swift
@@ -11,4 +11,5 @@ import Foundation
 protocol ImageRepositoryProtocol {
     func saveLocal(imageData: Data, fileName: String) -> AnyPublisher<URL, Error>
     func saveRemote(user: User, imageData: Data, fileName: String) -> AnyPublisher<URL, Error>
+    func deleteRemote(with url: URL) -> AnyPublisher<Void, Error>
 }

--- a/Doolda/Doolda/Domain/Interfaces/Repositories/PageRepositoryProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/Repositories/PageRepositoryProtocol.swift
@@ -13,4 +13,5 @@ protocol PageRepositoryProtocol {
     func updatePage(_ page: PageEntity) -> AnyPublisher<PageEntity, Error>
     func fetchPages(for pair: DDID) -> AnyPublisher<[PageEntity], Error>
     func deletePages(for pair: DDID) -> AnyPublisher<Void, Error>
+    func deletePage(for page: PageEntity) -> AnyPublisher<Void, Error>
 }

--- a/Doolda/Doolda/Domain/Interfaces/UseCases/ImageUseCaseProtocol.swift
+++ b/Doolda/Doolda/Domain/Interfaces/UseCases/ImageUseCaseProtocol.swift
@@ -12,4 +12,5 @@ import Foundation
 protocol ImageUseCaseProtocol {
     func saveLocal(image: CIImage) -> AnyPublisher<URL, Error>
     func saveRemote(for user: User, localUrl: URL) -> AnyPublisher<URL, Error>
+    func deleteRemote(with remoteUrl: URL) -> AnyPublisher<Void, Error>
 }

--- a/Doolda/Doolda/Domain/UseCases/GetRawPageUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/GetRawPageUseCase.swift
@@ -7,15 +7,32 @@
 
 import Combine
 import Foundation
+import FirebaseStorage
 
 final class GetRawPageUseCase: GetRawPageUseCaseProtocol {
     private let rawPageRepository: RawPageRepositoryProtocol
+    private let pageRepository: PageRepositoryProtocol
     
-    init(rawPageRepository: RawPageRepositoryProtocol) {
+    private var cancellables: Set<AnyCancellable> = []
+    
+    init(rawPageRepository: RawPageRepositoryProtocol, pageRepository: PageRepositoryProtocol) {
         self.rawPageRepository = rawPageRepository
+        self.pageRepository = pageRepository
     }
     
     func getRawPageEntity(metaData: PageEntity) -> AnyPublisher<RawPageEntity, Error> {
         return self.rawPageRepository.fetch(metaData: metaData)
+            .catch { [weak self] error -> AnyPublisher<RawPageEntity, Error> in
+                let storageError = StorageErrorCode(rawValue: (error as NSError).code)
+                if storageError == .objectNotFound { self?.deleteDummyPage(for: metaData) }
+                return Fail(error: error).eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    private func deleteDummyPage(for page: PageEntity) {
+        self.pageRepository.deletePage(for: page)
+            .sink (receiveCompletion: { _ in }, receiveValue: { _ in })
+            .store(in: &self.cancellables)
     }
 }

--- a/Doolda/Doolda/Domain/UseCases/ImageUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/ImageUseCase.swift
@@ -45,4 +45,8 @@ final class ImageUseCase: ImageUseCaseProtocol {
         let imageName = UUID().uuidString
         return imageRepository.saveRemote(user: user, imageData: imageData, fileName: imageName)
     }
+    
+    func deleteRemote(with remoteUrl: URL) -> AnyPublisher<Void, Error> {
+        return imageRepository.deleteRemote(with: remoteUrl)
+    }
 }

--- a/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
+++ b/Doolda/Doolda/EditPageScene/EditPageViewCoordinator.swift
@@ -65,7 +65,6 @@ final class EditPageViewCoordinator: BaseCoordinator {
     func start() {
         DispatchQueue.main.async {
             let fileManagerPersistenceService = FileManagerPersistenceService.shared
-            let urlSessionNetworkService = URLSessionNetworkService.shared
             let firebaseNetworkService = FirebaseNetworkService.shared
             let coreDataPersistenceService = CoreDataPersistenceService.shared
             let coreDataPageEntityPersistenceService = CoreDataPageEntityPersistenceService(
@@ -75,7 +74,7 @@ final class EditPageViewCoordinator: BaseCoordinator {
             let pairRepository = PairRepository(networkService: firebaseNetworkService)
             let imageRepository = ImageRepository(
                 fileManagerService: fileManagerPersistenceService,
-                networkService: urlSessionNetworkService
+                networkService: firebaseNetworkService
             )
             let pageRepository = PageRepository(
                 networkService: FirebaseNetworkService.shared,
@@ -160,9 +159,9 @@ final class EditPageViewCoordinator: BaseCoordinator {
     
     private func addPhotoComponent() {
         let fileManagerPersistenceService = FileManagerPersistenceService.shared
-        let urlSessionNetworkService = URLSessionNetworkService.shared
+        let firebaseNetworkService = FirebaseNetworkService.shared
         
-        let imageRepository = ImageRepository(fileManagerService: fileManagerPersistenceService, networkService: urlSessionNetworkService)
+        let imageRepository = ImageRepository(fileManagerService: fileManagerPersistenceService, networkService: firebaseNetworkService)
         let imageUseCase = ImageUseCase(imageRepository: imageRepository)
         let imageComposeUseCaes = ImageComposeUseCase()
         

--- a/Doolda/Doolda/PageDetailScene/PageDetailViewCoordinator.swift
+++ b/Doolda/Doolda/PageDetailScene/PageDetailViewCoordinator.swift
@@ -61,7 +61,12 @@ final class PageDetailViewCoordinator: BaseCoordinator {
             fileManagerPersistenceService: fileManagerPersistenceService
         )
 
-        let getRawPageUseCase = GetRawPageUseCase(rawPageRepository: rawPageRepository)
+        let pageRepository = PageRepository(
+            networkService: FirebaseNetworkService.shared,
+            pageEntityPersistenceService: coreDataPageEntityPersistenceService
+        )
+
+        let getRawPageUseCase = GetRawPageUseCase(rawPageRepository: rawPageRepository, pageRepository: pageRepository)
 
         let viewModel = PageDetaillViewModel(
             sceneId: self.identifier,

--- a/Doolda/Doolda/Service/Networks/FirebaseNetworkService.swift
+++ b/Doolda/Doolda/Service/Networks/FirebaseNetworkService.swift
@@ -17,6 +17,7 @@ class FirebaseNetworkService: FirebaseNetworkServiceProtocol {
         case dataUploadFailed
         case dataDownloadFailed
         case requestTimeOut
+        case deleteStorageFileFailed
         
         var errorDescription: String? {
             switch self {
@@ -25,6 +26,7 @@ class FirebaseNetworkService: FirebaseNetworkServiceProtocol {
             case .dataUploadFailed: return "데이터 업로드에 실패"
             case .dataDownloadFailed: return "데이터 다운로드에 실패"
             case .requestTimeOut: return "요청 시간 초과"
+            case .deleteStorageFileFailed: return "파일 제거에 실패했습니다."
             }
         }
     }
@@ -207,6 +209,20 @@ class FirebaseNetworkService: FirebaseNetworkServiceProtocol {
         }
         .timeout(.seconds(Self.timeOutLimit), scheduler: scheduler, customError: { Errors.requestTimeOut })
         .eraseToAnyPublisher()
+    }
+    
+    func deleteStorageFile(path: String, fileName: String) -> AnyPublisher<Void, Error> {
+        let storageReference = Storage.storage().reference(withPath: path).child(fileName)
+        return storageReference.delete()
+            .mapError{ _ in Errors.deleteStorageFileFailed }
+            .eraseToAnyPublisher()
+    }
+    
+    func deleteStorageFile(for url: URL) -> AnyPublisher<Void, Error> {
+        let storageReference = Storage.storage().reference(forURL: url.absoluteString)
+        return storageReference.delete()
+            .mapError{ _ in Errors.deleteStorageFileFailed }
+            .eraseToAnyPublisher()
     }
     
     func observeDocument(collection: FirebaseCollection, document: String) -> AnyPublisher<[String: Any], Error> {


### PR DESCRIPTION
## 이슈 목록
- [x] #602 

## 특이사항
* 이슈 원인은 페이지를 저장할 때, page / rawPage / recentlyEditedUser 이 3개를 merge해서 파베에 저장하고 있기 때문이었습니다! 만약 page는 저장됐는데 rawPage 저장에 실패할 경우, 불러올 수 있는 정보가 없어 무한로딩 중인 페이지가 생김.
* 이렇게 3개의 publisher를 merge로 처리하면 #602 이슈 외에도 다른 문제가 발생할 수 있을것 같습니다. 예를들어 recentlyEditedUser만 저장에 실패하면 내가 페이지를 작성했음에도 내 친구에게로 차례가 넘어가지 않는 이슈가 있을거고, page만 저장에 실패할 경우 쓰이지도 않는 rawPage 데이터가 파베에 더미로 남아있을거고 등등..
* 따라서 저장 로직을 merge가 아니라 flatMap으로 변경하였고, rawPage를 fetch 할 때 파베에서 불러올 수 없으면 대응되는 pageEntity 까지 파베에서 같이 제거해주도록 했습니다. 
* 오류가 발생한 rawPage를 제거할 때 image 파일까지 파베에서 찾아 제거해주는게 맞는데, 일단 이 이슈랑 분리해서 작업하는게 나을것 같아 처리하지 않았습니다.

| 스크린샷|
| :--: |
| ![Simulator Screen Recording - iPhone 12 - 2022-07-01 at 19 24 44](https://user-images.githubusercontent.com/61934702/176939762-bdf8c20a-a1cb-444e-8c04-8ae3c158ac9a.gif) |

위와 같이 무한로딩 페이지가 fetch 되면 이를 알아서 제거하도록 수정되었습니다!!

## 셀프체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [ ] 변경사항이 효과적이거나 동작이 작동한다는 것을 보증하는 테스트를 추가하였는가?
- [ ] 새로운 테스트와 기존의 테스트가 변경사항에 대해 만족하는가?

