### PR TITLE
1차 심사 Reject에 대한 hotfix

### DIFF
--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -3088,6 +3088,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3097,7 +3098,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -3111,7 +3112,7 @@
 				CODE_SIGN_ENTITLEMENTS = Doolda/Doolda.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9DGN7522H6;
+				DEVELOPMENT_TEAM = 5HZQ3M82FA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Doolda/Resources/Info.plist;
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
@@ -3120,16 +3121,17 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = minglely.com.doolda;
+				PRODUCT_BUNDLE_IDENTIFIER = com.seunghun.doolda;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/Doolda/Doolda.xcodeproj/project.pbxproj
+++ b/Doolda/Doolda.xcodeproj/project.pbxproj
@@ -3082,7 +3082,7 @@
 				DEVELOPMENT_TEAM = 5HZQ3M82FA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Doolda/Resources/Info.plist;
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "다이어리를 사진으로 꾸미기 위해 먼저 사진 라이브러리 접근을 허용해주세요!";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
@@ -3115,7 +3115,7 @@
 				DEVELOPMENT_TEAM = 5HZQ3M82FA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Doolda/Resources/Info.plist;
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "다이어리를 사진으로 꾸미기 위해 먼저 사진 라이브러리 접근을 허용해주세요!";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;

--- a/Doolda/Doolda/AuthenticationScene/AuthenticationViewModel.swift
+++ b/Doolda/Doolda/AuthenticationScene/AuthenticationViewModel.swift
@@ -140,7 +140,8 @@ final class AuthenticationViewModel: AuthenticationViewModelProtocol {
             .sink { [weak self] completion in
                 guard case .failure(let error) = completion else { return }
                 switch error {
-                case FirebaseNetworkService.Errors.invalidDocumentSnapshot: self?.createUserAndValidate(with: user.uid)
+                // 유저가 Apple Login으로 회원가입/로그인 모두 진행하는 경우
+                case GetMyIdUseCase.Errors.failedToAcquireId(_): self?.createUserAndValidate(with: user.uid)
                 default: self?.error = error
                 }
             } receiveValue: { [weak self] ddid in

--- a/Doolda/Doolda/Data/Repositories/UserRepository.swift
+++ b/Doolda/Doolda/Data/Repositories/UserRepository.swift
@@ -7,26 +7,6 @@
 import Combine
 import Foundation
 
-enum UserRepositoryError: LocalizedError {
-    case nilUserId
-    case nilFriendId
-    case DTOInitError
-    case savePairIdFail
-    
-    var errorDescription: String? {
-        switch self {
-        case .nilUserId:
-            return "유저의 아이디가 존재하지 않습니다."
-        case .nilFriendId:
-            return "친구의 아이디가 존재하지 않습니다."
-        case .DTOInitError:
-            return "DataTransferObjects가 올바르지 않습니다."
-        case .savePairIdFail:
-            return "PairID를 저장하는데 실패했습니다"
-        }
-    }
-}
-
 class UserRepository: UserRepositoryProtocol {
     private let userDefaultsPersistenceService: UserDefaultsPersistenceServiceProtocol
     private let firebaseNetworkService: FirebaseNetworkServiceProtocol

--- a/Doolda/Doolda/Domain/UseCases/GetMyIdUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/GetMyIdUseCase.swift
@@ -9,6 +9,19 @@ import Combine
 import Foundation
 
 final class GetMyIdUseCase: GetMyIdUseCaseProtocol {
+    enum Errors: LocalizedError {
+        case failedToAcquireId(reason: Error?)
+
+        var errorDescription: String? {
+            switch self {
+            case .failedToAcquireId(let reason):
+                if let reason = reason {
+                    return "\(reason.localizedDescription)(으)로 인해 ID를 얻어오는 데 실패했습니다."
+                }
+                return "ID를 얻어오는 데 실패하였습니다."
+            }
+        }
+    }
     private let userRepository: UserRepositoryProtocol
         
     init(userRepository: UserRepositoryProtocol) {
@@ -17,5 +30,7 @@ final class GetMyIdUseCase: GetMyIdUseCaseProtocol {
     
     func getMyId(for uid: String) -> AnyPublisher<DDID?, Error> {
         return self.userRepository.getMyId(for: uid)
+            .mapError { Errors.failedToAcquireId(reason: $0) }
+            .eraseToAnyPublisher()
     }
 }

--- a/Doolda/Doolda/Domain/UseCases/GetUserUseCase.swift
+++ b/Doolda/Doolda/Domain/UseCases/GetUserUseCase.swift
@@ -9,6 +9,20 @@ import Combine
 import Foundation
 
 final class GetUserUseCase: GetUserUseCaseProtocol {
+    enum Errors: LocalizedError {
+        case failedToAcquireUser(reason: Error?)
+
+        var errorDescription: String? {
+            switch self {
+            case .failedToAcquireUser(let reason):
+                if let reason = reason {
+                    return "\(reason.localizedDescription)으로 인해 User를 얻어오는 데 실패했습니다."
+                }
+                return "유저를 얻어오는 데 실패했습니다."
+            }
+        }
+    }
+
     private let userRepository: UserRepositoryProtocol
     
     init(userRepository: UserRepositoryProtocol) {
@@ -17,5 +31,7 @@ final class GetUserUseCase: GetUserUseCaseProtocol {
     
     func getUser(for id: DDID) -> AnyPublisher<User, Error> {
         return self.userRepository.fetchUser(id)
+            .mapError { Errors.failedToAcquireUser(reason: $0) }
+            .eraseToAnyPublisher()
     }
 }

--- a/Doolda/Doolda/Doolda.entitlements
+++ b/Doolda/Doolda/Doolda.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/Doolda/Doolda/SplashScene/SplashViewController.swift
+++ b/Doolda/Doolda/SplashScene/SplashViewController.swift
@@ -99,8 +99,13 @@ final class SplashViewController: UIViewController {
         self.viewModel.errorPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
-                guard error != nil else { return }
-                self?.showErrorAlert()
+                guard let error = error else { return }
+
+                switch error._code {
+                // Network Connection에 문제가 있는 경우
+                case 17020: self?.showErrorAlert()
+                default: self?.showLogoutAndRetryAlert(with: error)
+                }
             }
             .store(in: &cancellables)
     }
@@ -111,6 +116,16 @@ final class SplashViewController: UIViewController {
         let alert = UIAlertController.networkAlert { _ in
             self.viewModel.validateAccount()
         }
+        self.present(alert, animated: true)
+    }
+
+    private func showLogoutAndRetryAlert(with error: Error) {
+        let alert = UIAlertController.defaultAlert(
+            title: "에러 발생",
+            message: error.localizedDescription,
+            buttonTitle: "다시 시도") { [weak self] _ in
+                self?.viewModel.didTapRetryButton()
+            }
         self.present(alert, animated: true)
     }
 }

--- a/Doolda/Doolda/SplashScene/SplashViewModel.swift
+++ b/Doolda/Doolda/SplashScene/SplashViewModel.swift
@@ -13,6 +13,7 @@ import FirebaseAuth
 protocol SplashViewModelInput {
     func validateAccount()
     func deinitRequested()
+    func didTapRetryButton()
 }
 
 protocol SplashViewModelOutput {
@@ -63,6 +64,18 @@ final class SplashViewModel: SplashViewModelProtocol {
             object: nil,
             userInfo: [BaseCoordinator.Keys.sceneId: self.sceneId]
         )
+    }
+
+    func didTapRetryButton() {
+        do {
+            try authenticateUseCase.signOut()
+            NotificationCenter.default.post(
+                name: AppCoordinator.Notifications.appRestartSignal,
+                object: nil
+            )
+        } catch {
+            self.error = error
+        }
     }
     
     /// get current firebase user using firebase auth.

--- a/Doolda/Doolda/Support/Extensions/UIAlertController+Extensions.swift
+++ b/Doolda/Doolda/Support/Extensions/UIAlertController+Extensions.swift
@@ -9,9 +9,11 @@ import UIKit
 
 extension UIAlertController {
     static func networkAlert(refreshAction: @escaping (UIAlertAction) -> Void) -> UIAlertController {
-        let alert = UIAlertController(title: "네트워크 오류",
-                                      message: "Wifi나 3G/LTE/5G를 연결 후 재시도 해주세요🙏",
-                                      preferredStyle: .alert)
+        let alert = UIAlertController(
+            title: "네트워크 오류",
+            message: "Wifi나 3G/LTE/5G를 연결 후 재시도 해주세요🙏",
+            preferredStyle: .alert
+        )
         let refreshAlertAction = UIAlertAction(title: "재시도", style: .default, handler: refreshAction)
         let exitAlertAction = UIAlertAction(title: "종료", style: .destructive) { _ in exit(0) }
 


### PR DESCRIPTION
## 이슈 목록

| Splash에서 네트워크에러가 아닌 에러 발생 | 사진 권한 요청 텍스트 추가 |
|:-:|:-:|
| <img width="400" src="https://user-images.githubusercontent.com/20262392/177023065-bf613ec4-e236-4feb-990b-464a672f51b5.gif"> | <img width="400" src="https://user-images.githubusercontent.com/20262392/177023061-d9ef94e5-5217-4bc7-b461-f9d50e15e5ec.PNG"> |


- efe6368: 계정은 있는데 연결된 User가 없는 경우에 대한 에러를 추가했고, 네트워크 에러의 경우에만 재시작 alert이 뜨도록 수정해줬습니다. 갑자기 하게 된 이유는.. 저희 DB는 날리고 Authentication은 안날렸더니 계속 네트워크에러가 나더라구요. 그래서 까보니까 모든 에러를 네트워크로 처리하는게 문제길래 칼좀뽑아봤습니다.
-  b4f6d2d: 리젝 사유 중 하나가 사진 권한 요청시 메시지가 없다는 거였는데요, 이번에 추가했습니다. 왜 없었던건지 모르겠네요.
- cf0dec6: 리젝 사유 중 또 다른 하나가 애플로그인 버튼 무반응 문제였는데요, 지승님께서 말씀주신대로 Debug모드에서만 동작하도록 되어있던 것 같습니다. release에서도 동작하는진 일단 testflight 태워봐야 알 것 같은 느낌? (빌드 중입니다)